### PR TITLE
Add Minio bucket commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,14 @@ pub enum Command {
     /// Install Helm only
     Helm,
     /// Deploy Minio
-    Minio,
+    Minio {
+        /// Create bucket in Minio
+        #[arg(long)]
+        create_bucket: Option<String>,
+        /// Delete bucket from Minio
+        #[arg(long)]
+        delete_bucket: Option<String>,
+    },
     /// Deploy Gitlab
     Gitlab,
     /// Deploy Prometheus

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,16 @@ fn main() -> std::result::Result<(), Box<dyn Error>> {
         Command::Helm => {
             helm::install_helm(instance_k3_name)?;
         }
-        Command::Minio => {
-            minio::deploy_minio(instance_k3_name)?;
+        Command::Minio { create_bucket, delete_bucket } => {
+            if create_bucket.is_none() && delete_bucket.is_none() {
+                minio::deploy_minio(instance_k3_name)?;
+            }
+            if let Some(b) = create_bucket {
+                minio::create_bucket(instance_k3_name, &b)?;
+            }
+            if let Some(b) = delete_bucket {
+                minio::delete_bucket(instance_k3_name, &b)?;
+            }
         }
         Command::Gitlab => {
             gitlab::deploy_gitlab(instance_k3_name)?;

--- a/src/minio.rs
+++ b/src/minio.rs
@@ -104,4 +104,18 @@ tenant:
 
    
     Ok(())
-  }
+}
+
+pub(crate) fn create_bucket(instance: &str, bucket: &str) -> std::result::Result<(), Box<dyn Error>> {
+    Command::new("wsl")
+        .args(&["-d", instance, "--", "sh", "-c", &format!("mc mb {}", bucket)])
+        .status()?;
+    Ok(())
+}
+
+pub(crate) fn delete_bucket(instance: &str, bucket: &str) -> std::result::Result<(), Box<dyn Error>> {
+    Command::new("wsl")
+        .args(&["-d", instance, "--", "sh", "-c", &format!("mc rb {}", bucket)])
+        .status()?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add helper functions to create and delete Minio buckets
- extend `minio` CLI subcommand with `--create-bucket` and `--delete-bucket`
- call bucket helpers from main entrypoint

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6867ba2a87688320b9ae499dc797081c