### PR TITLE
Add CI build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-rust@v1
+        with:
+          toolchain: stable
+      - run: cargo build --release
+      - uses: actions/upload-artifact@v4
+        with:
+          name: env-dev
+          path: target/release/env-dev


### PR DESCRIPTION
## Summary
- build the env-dev binary in GitHub Actions
- upload the compiled binary as an artifact

## Testing
- `cargo build --release`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6867c2519d108320af12f82837a81007