### PR TITLE
Update runtime Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 Command line interface to bootstrap and manage a local Kubernetes lab using Windows Subsystem for Linux (WSL).
 It installs a minimal Alpine distribution, a k3s cluster and common services such as Helm, MinIO, GitLab and Prometheus.
 
+The repository also provides a `Dockerfile` for running the compiled `env-dev`
+binary. The runtime image is based on **Alpine Linux 3.20** and installs the
+k3s binary using the official installation script (`curl -sfL https://get.k3s.io | sh -`).
+
 ## Requirements
 
 - Windows machine with **WSL2** enabled

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,8 @@ WORKDIR /src
 COPY . .
 RUN cargo build --release
 
-FROM debian:bookworm-slim
+FROM alpine:3.20
+RUN apk add --no-cache curl bash \
+    && curl -sfL https://get.k3s.io | sh -
 COPY --from=builder /src/target/release/env-dev /usr/local/bin/env-dev
 CMD ["/usr/local/bin/env-dev"]


### PR DESCRIPTION
## Summary
- use alpine 3.20 for runtime image
- install k3s with the official script
- document the new image base in README

## Testing
- `cargo fmt --all`
- `cargo test --quiet`
- `cargo build --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68684a4746b08320888663e5766248e4