### PR TITLE
Embed Alpine rootfs from CI image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,14 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - run: cargo build --release
+      - run: docker build -t env-dev-image -f docker/Dockerfile .
+      - run: docker save env-dev-image -o env-dev-image.tar
+      - run: WSL_IMAGE_ARCHIVE=env-dev-image.tar cargo build --release
       - uses: actions/upload-artifact@v4
         with:
           name: env-dev
           path: target/release/env-dev
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wsl-image
+          path: env-dev-image.tar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build-linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,4 +23,27 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: wsl-image
+          path: env-dev-image.tar
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - run: docker build -t env-dev-image -f docker/Dockerfile .
+        shell: bash
+      - run: docker save env-dev-image -o env-dev-image.tar
+        shell: bash
+      - run: WSL_IMAGE_ARCHIVE=env-dev-image.tar cargo build --release
+        shell: bash
+      - uses: actions/upload-artifact@v4
+        with:
+          name: env-dev.exe
+          path: target/release/env-dev.exe
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wsl-image-windows
           path: env-dev-image.tar

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+assets/*.tar*

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Command line interface to bootstrap and manage a local Kubernetes lab using Wind
 It installs a minimal Alpine distribution, a k3s cluster and common services such as Helm, MinIO, GitLab and Prometheus.
 The Docker image archive used for the WSL distro is generated during the GitHub Action build and embedded in the binary, allowing installation to run completely offline.
 
+CI builds produce both Linux and Windows (x86_64) binaries. The Windows executable is available as `env-dev.exe`.
+
 The repository also provides a `Dockerfile` for running the compiled `env-dev`
 binary. The runtime image is based on **Alpine Linux 3.20**, installs `openrc` so
 the k3s install script can run, and downloads the k3s binary using

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ It installs a minimal Alpine distribution, a k3s cluster and common services suc
 The Docker image archive used for the WSL distro is generated during the GitHub Action build and embedded in the binary, allowing installation to run completely offline.
 
 The repository also provides a `Dockerfile` for running the compiled `env-dev`
-binary. The runtime image is based on **Alpine Linux 3.20** and installs the
-k3s binary using the official installation script (`curl -sfL https://get.k3s.io | sh -`).
+binary. The runtime image is based on **Alpine Linux 3.20**, installs `openrc` so
+the k3s install script can run, and downloads the k3s binary using
+`INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_ENABLE=true curl -sfL https://get.k3s.io | sh -`.
 
 When compiling the project, set the `WSL_IMAGE_ARCHIVE` environment variable to
 the Docker image tarball produced by the CI workflow so the archive can be

--- a/README.md
+++ b/README.md
@@ -2,10 +2,15 @@
 
 Command line interface to bootstrap and manage a local Kubernetes lab using Windows Subsystem for Linux (WSL).
 It installs a minimal Alpine distribution, a k3s cluster and common services such as Helm, MinIO, GitLab and Prometheus.
+The Docker image archive used for the WSL distro is generated during the GitHub Action build and embedded in the binary, allowing installation to run completely offline.
 
 The repository also provides a `Dockerfile` for running the compiled `env-dev`
 binary. The runtime image is based on **Alpine Linux 3.20** and installs the
 k3s binary using the official installation script (`curl -sfL https://get.k3s.io | sh -`).
+
+When compiling the project, set the `WSL_IMAGE_ARCHIVE` environment variable to
+the Docker image tarball produced by the CI workflow so the archive can be
+embedded into the binary.
 
 ## Requirements
 

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,17 @@
-extern crate embed_resource;
+use std::env;
+use std::fs;
+use std::path::Path;
 
 fn main() {
-    //embed_resource::compile("env-dev.manifest.rc", embed_resource::NONE);
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
+    let dest = Path::new(&out_dir).join("wsl-image.tar");
+    if let Ok(image_path) = env::var("WSL_IMAGE_ARCHIVE") {
+        fs::copy(&image_path, &dest).expect("failed to copy image archive");
+    } else {
+        // create an empty placeholder so compilation still succeeds
+        fs::write(&dest, &[] as &[u8]).expect("failed to create placeholder image");
+        println!("cargo:warning=WSL_IMAGE_ARCHIVE not provided; offline install won't work");
+    }
+    println!("cargo:rustc-env=WSL_IMAGE_PATH={}", dest.display());
 }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,8 @@ COPY . .
 RUN cargo build --release
 
 FROM alpine:3.20
-RUN apk add --no-cache curl bash \
-    && curl -sfL https://get.k3s.io | sh -
+RUN apk add --no-cache curl bash openrc \
+    && INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_ENABLE=true \
+    curl -sfL https://get.k3s.io | sh -
 COPY --from=builder /src/target/release/env-dev /usr/local/bin/env-dev
 CMD ["/usr/local/bin/env-dev"]

--- a/src/alpine.rs
+++ b/src/alpine.rs
@@ -1,52 +1,18 @@
-use reqwest::blocking::Client;
-use serde_yaml::Value;
 use std::error::Error;
-use std::io::Write;
-use std::{fs, path::Path, process::Command};
+use std::{fs, io::Write, path::Path, process::Command};
 
 pub fn import_alpine(instance_name: &str) -> Result<(), Box<dyn Error>> {
-    let yaml_url =
-        "https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/x86_64/latest-releases.yaml";
-
-    // Téléchargez le fichier YAML de manière synchrone
-    let client = Client::new();
-    let yaml_content = client.get(yaml_url).send()?.text()?;
-
-    // Parsez le YAML
-    let docs: Vec<Value> = serde_yaml::from_str(&yaml_content)?;
-    let mut file_name = String::new();
-    for doc in docs {
-        if let Some(flavor) = doc["flavor"].as_str() {
-            if flavor == "alpine-minirootfs" {
-                if let Some(file) = doc["file"].as_str() {
-                    file_name = file.to_string();
-                    break;
-                }
-            }
-        }
-    }
-
-    if file_name.is_empty() {
-        return Err("Alpine minirootfs file not found".into());
-    }
-    println!("Alpine: {}", file_name);
-    let alpine_url = format!(
-        "https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/x86_64/{}",
-        file_name
-    );
-
-    //let alpine_url =  "https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/x86_64/alpine-netboot-3.20.0-x86_64.tar.gz";
     let folder = format!("C:\\wsldistros\\{}", instance_name);
     let download_folder = Path::new(&folder);
     if !download_folder.exists() {
         fs::create_dir_all(download_folder)?;
     }
-    let tar_gz_file = download_folder.join("alpine-minirootfs.tar.gz");
+    let tar_file = download_folder.join("wsl-image.tar");
 
-    if !tar_gz_file.exists() {
-        let response = client.get(alpine_url).send()?;
-        let mut file_alpine = fs::File::create(&tar_gz_file)?;
-        file_alpine.write_all(&response.bytes()?)?;
+    if !tar_file.exists() {
+        let bytes = include_bytes!(env!("WSL_IMAGE_PATH"));
+        let mut file_alpine = fs::File::create(&tar_file)?;
+        file_alpine.write_all(bytes)?;
     }
 
     // Exécutez les commandes WSL
@@ -56,7 +22,7 @@ pub fn import_alpine(instance_name: &str) -> Result<(), Box<dyn Error>> {
         .arg("--import")
         .arg(instance_name)
         .arg(download_folder.to_str().unwrap())
-        .arg(tar_gz_file.to_str().unwrap())
+        .arg(tar_file.to_str().unwrap())
         .arg("--version 2")
         .output()
         .expect("Échec de l'exécution de la commande WSL --import");


### PR DESCRIPTION
## Summary
- use `WSL_IMAGE_ARCHIVE` environment variable in build script
- embed Docker image produced in CI instead of stored asset
- adjust workflow to build image and provide archive to cargo
- update README for new build process

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6868b195233483209d2b76ebc9420f87