### PR TITLE
Update README with WSL image instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ cargo run -- <COMMAND>
 - `update` - update the K3S and Helm binaries inside the WSL distro
 - `cuda` - install CUDA support in the WSL distro when an NVIDIA GPU is detected
 
+### Pre-built WSL image
+
+You can import a ready-to-use WSL distro instead of building it from scratch. Go
+to the repository's **Actions** tab on GitHub and download the `env-dev-image.tar`
+artifact from the latest successful workflow. When available, the Linux image is
+published as `env-dev-image-linux.tar` and the Windows image as
+`env-dev-image-windows.tar`.
+
+Set the `WSL_IMAGE_ARCHIVE` environment variable to the downloaded archive
+before running commands, for example:
+
+```bash
+export WSL_IMAGE_ARCHIVE=/path/to/env-dev-image.tar
+cargo run -- install
+```
+
 ### Examples
 
 ```bash


### PR DESCRIPTION
## Summary
- document downloading the `env-dev-image.tar` artifact from GitHub Actions
- describe how to use `WSL_IMAGE_ARCHIVE` and mention Linux/Windows images

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6868cbf9bc98832086dffb13eab2d25d