### PR TITLE
Remove leftover build dependency reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,9 +357,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
## Summary
- update `Cargo.lock` using `cargo update`
- ensure `cargo check` succeeds

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68728bdaefb083208f26bd7308ba2529