### PR TITLE
Fix WSL version args

### DIFF
--- a/src/alpine.rs
+++ b/src/alpine.rs
@@ -23,7 +23,8 @@ pub fn import_alpine(instance_name: &str) -> Result<(), Box<dyn Error>> {
         .arg(instance_name)
         .arg(download_folder.to_str().unwrap())
         .arg(tar_file.to_str().unwrap())
-        .arg("--version 2")
+        .arg("--version")
+        .arg("2")
         .output()
         .expect("Échec de l'exécution de la commande WSL --import");
 


### PR DESCRIPTION
## Summary
- split WSL `--version` argument in Alpine import

## Testing
- `cargo build --quiet`
- `cargo install --path . --root target/install`


------
https://chatgpt.com/codex/tasks/task_e_687ece2545e88320a6e928887451ebcc