### PR TITLE
Fail build when WSL_IMAGE_ARCHIVE missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The repository also provides a `Dockerfile` used to build this image. It simply 
 
 When compiling the project, set the `WSL_IMAGE_ARCHIVE` environment variable to
 the Docker image tarball produced by the CI workflow so the archive can be
-embedded into the binary.
+embedded into the binary. Compilation will fail if this variable is not set.
 
 ## Requirements
 
@@ -56,7 +56,8 @@ To do so:
    archive.
 
 After downloading the archive, set the `WSL_IMAGE_ARCHIVE` environment variable
-to its path before running commands. For example:
+to its path before running commands. This variable is required at build time
+and the build will error if it is missing. For example:
 
 ```bash
 export WSL_IMAGE_ARCHIVE=/path/to/env-dev-image.tar

--- a/build.rs
+++ b/build.rs
@@ -5,13 +5,9 @@ use std::path::Path;
 fn main() {
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
     let dest = Path::new(&out_dir).join("wsl-image.tar");
-    if let Ok(image_path) = env::var("WSL_IMAGE_ARCHIVE") {
-        fs::copy(&image_path, &dest).expect("failed to copy image archive");
-    } else {
-        // create an empty placeholder so compilation still succeeds
-        fs::write(&dest, &[] as &[u8]).expect("failed to create placeholder image");
-        println!("cargo:warning=WSL_IMAGE_ARCHIVE not provided; offline install won't work");
-    }
+    let image_path = env::var("WSL_IMAGE_ARCHIVE")
+        .expect("WSL_IMAGE_ARCHIVE environment variable not set");
+    fs::copy(&image_path, &dest).expect("failed to copy image archive");
     println!("cargo:rustc-env=WSL_IMAGE_PATH={}", dest.display());
 }
 


### PR DESCRIPTION
## Summary
- stop silently embedding an empty WSL archive
- update docs to describe the new build requirement

## Testing
- `WSL_IMAGE_ARCHIVE=dummy.tar cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687ed680ea948320a2a47df78d758758