### PR TITLE
Add Cross.toml passthrough config

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[build.env]
+passthrough = ["WSL_IMAGE_ARCHIVE"]


### PR DESCRIPTION
## Summary
- allow `cross` to pass `WSL_IMAGE_ARCHIVE` env var by default

## Testing
- `cross build` *(fails: no container engine found)*

------
https://chatgpt.com/codex/tasks/task_e_687edc5a8eec8320a6d560765aba4a5b