### PR TITLE
Add option to override WSL distro path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rand = "0.8.5"
 tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros","fs"] }
 thiserror = "1.0.58"
 winapi = "0.3.9"
-clap = { version = "4.5.3", features = ["derive"] }
+clap = { version = "4.5.3", features = ["derive", "env"] }
 windows = {version = "0.56.0", features = [
     "Win32_Foundation",
     "Win32_Security",

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Run the CLI with cargo followed by one of the available commands:
 cargo run -- <COMMAND>
 ```
 
+Use `--distro-path [PATH]` or the `HOMELAB_DISTRO_PATH` environment variable to
+change where the WSL distribution is stored. Providing the option without a
+value stores the files in the system temporary directory.
+
 ### Commands
 
 - `install` - import the k3s WSL image and install Helm

--- a/src/alpine.rs
+++ b/src/alpine.rs
@@ -1,11 +1,10 @@
 use std::error::Error;
-use std::{fs, io::Write, path::Path, process::Command};
+use std::{fs, io::Write, path::Path, path::PathBuf, process::Command};
 
-pub fn import_alpine(instance_name: &str) -> Result<(), Box<dyn Error>> {
-    let folder = format!("C:\\wsldistros\\{}", instance_name);
-    let download_folder = Path::new(&folder);
+pub fn import_alpine(instance_name: &str, base_dir: &Path) -> Result<(), Box<dyn Error>> {
+    let download_folder: PathBuf = base_dir.join(instance_name);
     if !download_folder.exists() {
-        fs::create_dir_all(download_folder)?;
+        fs::create_dir_all(&download_folder)?;
     }
     let tar_file = download_folder.join("wsl-image.tar");
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,14 @@
 use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(name = "homelab")]
 pub struct Cli {
+    /// Base directory where the WSL distro will be stored
+    /// Can also be set with the `HOMELAB_DISTRO_PATH` environment variable.
+    /// Providing the flag without a value defaults to the system temp directory.
+    #[arg(long, env = "HOMELAB_DISTRO_PATH", num_args = 0..=1, value_name = "PATH", default_missing_value = "")]
+    pub distro_path: Option<String>,
     #[command(subcommand)]
     pub command: Command,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,11 +19,16 @@ use cli::{Cli, Command};
 fn main() -> std::result::Result<(), Box<dyn Error>> {
     let args = Cli::parse();
     let instance_k3_name = "k3s";
+    let base_dir = match args.distro_path.as_deref() {
+        Some("") => std::env::temp_dir(),
+        Some(path) => std::path::PathBuf::from(path),
+        None => std::path::PathBuf::from("C:\\wsldistros"),
+    };
 
     match args.command {
         Command::Install => {
             println!("Importing k3s WSL image");
-            alpine::import_alpine(instance_k3_name)?;
+            alpine::import_alpine(instance_k3_name, &base_dir)?;
             println!("Configuring K3S");
             k3s::install_k3s(instance_k3_name)?;
             println!("Installation Helm");


### PR DESCRIPTION
## Summary
- allow overriding WSL distro location with `--distro-path` or `HOMELAB_DISTRO_PATH`
- default to the OS temp directory when the flag is present without a value
- update documentation

## Testing
- `cargo fmt`
- `WSL_IMAGE_ARCHIVE=/tmp/empty.tar cargo check`

------
https://chatgpt.com/codex/tasks/task_e_687f1b89daac8320926c7eb11481707f