### PR TITLE
Add logging for WSL image locations

### DIFF
--- a/src/alpine.rs
+++ b/src/alpine.rs
@@ -14,6 +14,9 @@ pub fn import_alpine(instance_name: &str, base_dir: &Path) -> Result<(), Box<dyn
         file_alpine.write_all(bytes)?;
     }
 
+    println!("Extracting image to {}", tar_file.display());
+    println!("Importing distro into {}", download_folder.display());
+
     // Exécutez les commandes WSL
     unregister(instance_name)?;
 


### PR DESCRIPTION
## Summary
- add log lines to show image extraction and import directories

## Testing
- `cargo test --quiet` *(fails: `WSL_IMAGE_ARCHIVE` environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_688655a871348320987d857681d4584a