### PR TITLE
Fix WSL image extraction check

### DIFF
--- a/src/alpine.rs
+++ b/src/alpine.rs
@@ -8,7 +8,12 @@ pub fn import_alpine(instance_name: &str, base_dir: &Path) -> Result<(), Box<dyn
     }
     let tar_file = download_folder.join("wsl-image.tar");
 
-    if !tar_file.exists() {
+    if !tar_file.exists() || tar_file.metadata()?.len() == 0 {
+        if tar_file.exists() {
+            println!(
+                "Existing tar file was empty, overwriting with embedded image"
+            );
+        }
         let bytes = include_bytes!(env!("WSL_IMAGE_PATH"));
         let mut file_alpine = fs::File::create(&tar_file)?;
         file_alpine.write_all(bytes)?;


### PR DESCRIPTION
## Summary
- validate tar file size when importing the embedded WSL image
- recreate the tar file if it exists but is empty

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6886ffc899308320b8b7ad5f3aa9a4a1