### PR TITLE
Add Tauri build workflow with service installers

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -1,0 +1,42 @@
+name: Build Tauri
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: x86_64-pc-windows-msvc
+          override: true
+      - name: Build services
+        shell: bash
+        run: |
+          cd home-dns
+          cargo build --release
+          cd ../home-proxy
+          cargo build --release
+      - name: Copy service binaries
+        shell: bash
+        run: |
+          mkdir -p home-lab/src-tauri/resources
+          cp home-dns/target/release/home-dns.exe home-lab/src-tauri/resources/
+          cp home-proxy/target/release/home-proxy.exe home-lab/src-tauri/resources/
+      - name: Build Tauri app
+        working-directory: home-lab
+        run: |
+          npm ci
+          npm run tauri build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: installer
+          path: home-lab/src-tauri/target/release/bundle/**/*

--- a/home-lab/src-tauri/resources/install-services.nsh
+++ b/home-lab/src-tauri/resources/install-services.nsh
@@ -1,0 +1,9 @@
+!macro NSIS_HOOK_POSTINSTALL
+  nsExec::Exec '"$INSTDIR\\home-dns.exe" install'
+  nsExec::Exec '"$INSTDIR\\home-proxy.exe" install'
+!macroend
+
+!macro NSIS_HOOK_POSTUNINSTALL
+  nsExec::Exec '"$INSTDIR\\home-dns.exe" uninstall'
+  nsExec::Exec '"$INSTDIR\\home-proxy.exe" uninstall'
+!macroend

--- a/home-lab/src-tauri/resources/install-services.wxi
+++ b/home-lab/src-tauri/resources/install-services.wxi
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Include xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <CustomAction Id="InstallHomeDns" ExeCommand="[INSTALLFOLDER]home-dns.exe install" Execute="deferred" Return="check"/>
+    <CustomAction Id="InstallHomeProxy" ExeCommand="[INSTALLFOLDER]home-proxy.exe install" Execute="deferred" Return="check"/>
+    <CustomAction Id="UninstallHomeDns" ExeCommand="[INSTALLFOLDER]home-dns.exe uninstall" Execute="deferred" Return="check"/>
+    <CustomAction Id="UninstallHomeProxy" ExeCommand="[INSTALLFOLDER]home-proxy.exe uninstall" Execute="deferred" Return="check"/>
+    <InstallExecuteSequence>
+      <Custom Action="InstallHomeDns" After="InstallFinalize">NOT Installed</Custom>
+      <Custom Action="InstallHomeProxy" After="InstallFinalize">NOT Installed</Custom>
+      <Custom Action="UninstallHomeDns" Before="RemoveFiles">REMOVE="ALL"</Custom>
+      <Custom Action="UninstallHomeProxy" Before="RemoveFiles">REMOVE="ALL"</Custom>
+    </InstallExecuteSequence>
+  </Fragment>
+</Include>

--- a/home-lab/src-tauri/tauri.conf.json
+++ b/home-lab/src-tauri/tauri.conf.json
@@ -28,6 +28,20 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "resources": [
+      "resources/home-dns.exe",
+      "resources/home-proxy.exe"
+    ],
+    "windows": {
+      "nsis": {
+        "installerHooks": "resources/install-services.nsh"
+      },
+      "wix": {
+        "fragmentPaths": [
+          "resources/install-services.wxi"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- build Windows installer for Tauri app via GitHub Actions
- include home-dns and home-proxy executables in bundle
- install/uninstall services through NSIS and WiX scripts

## Testing
- `cargo test --manifest-path home-dns/Cargo.toml`
- `cargo test --manifest-path home-proxy/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68931972690c83208b890c7dde5ad2d3