### PR TITLE
Build Windows service binaries in workflow

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -24,15 +24,15 @@ jobs:
         shell: bash
         run: |
           cd home-dns
-          cargo build --release
+          cargo build --release --target x86_64-pc-windows-msvc
           cd ../home-proxy
-          cargo build --release
+          cargo build --release --target x86_64-pc-windows-msvc
       - name: Copy service binaries
         shell: bash
         run: |
           mkdir -p home-lab/src-tauri/resources
-          cp home-dns/target/release/home-dns.exe home-lab/src-tauri/resources/
-          cp home-proxy/target/release/home-proxy.exe home-lab/src-tauri/resources/
+          cp home-dns/target/x86_64-pc-windows-msvc/release/home-dns.exe home-lab/src-tauri/resources/
+          cp home-proxy/target/x86_64-pc-windows-msvc/release/home-proxy.exe home-lab/src-tauri/resources/
       - uses: actions/upload-artifact@v4
         with:
           name: installer


### PR DESCRIPTION
## Summary
- build service crates for Windows target in workflow
- adjust service binary paths to include target directory

## Testing
- `cargo test` (home-dns)
- `cargo test` (home-proxy)


------
https://chatgpt.com/codex/tasks/task_e_6893acb957b88320801bb06281756c3a