### PR TITLE
Build Windows service binaries with explicit paths

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -23,10 +23,9 @@ jobs:
       - name: Build services
         shell: bash
         run: |
-          cd home-dns
-          cargo build --release --target x86_64-pc-windows-msvc
-          cd ../home-proxy
-          cargo build --release --target x86_64-pc-windows-msvc
+          for crate in home-dns home-proxy; do
+            cargo build --release --target x86_64-pc-windows-msvc --manifest-path $crate/Cargo.toml
+          done
       - name: Copy service binaries
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- build `home-dns` and `home-proxy` for Windows target using manifest paths
- copy Windows service binaries from target-specific directories

## Testing
- `cargo test --manifest-path home-dns/Cargo.toml`
- `cargo test --manifest-path home-proxy/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6893aedf2b1c8320af870161487c78f1