### PR TITLE
Use static CRT for Windows build

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-C target-feature=+crt-static"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- ensure Windows cross-compilation uses static C runtime

## Testing
- `cross build --target x86_64-pc-windows-gnu --manifest-path home-dns/Cargo.toml` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689438dfe03083208470e90d33e91e60