### PR TITLE
build: use cross for windows gnu

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -20,20 +20,22 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          target: x86_64-pc-windows-msvc
+          target: x86_64-pc-windows-gnu
           override: true
+      - name: Installer cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
       - name: Build services
         shell: bash
         run: |
           for crate in home-dns home-proxy; do
-            cargo build --release --target x86_64-pc-windows-msvc --manifest-path $crate/Cargo.toml
+            cross build --release --target x86_64-pc-windows-gnu --manifest-path $crate/Cargo.toml
           done
       - name: Copy service binaries
         shell: bash
         run: |
           mkdir -p home-lab/src-tauri/resources
-          cp home-dns/target/x86_64-pc-windows-msvc/release/home-dns.exe home-lab/src-tauri/resources/
-          cp home-proxy/target/x86_64-pc-windows-msvc/release/home-proxy.exe home-lab/src-tauri/resources/
+          cp home-dns/target/x86_64-pc-windows-gnu/release/home-dns.exe home-lab/src-tauri/resources/
+          cp home-proxy/target/x86_64-pc-windows-gnu/release/home-proxy.exe home-lab/src-tauri/resources/
       - uses: actions/upload-artifact@v4
         with:
           name: installer


### PR DESCRIPTION
## Summary
- install and leverage cross for Windows GNU builds
- target `x86_64-pc-windows-gnu` for service builds

## Testing
- `cargo check --target x86_64-pc-windows-gnu --manifest-path home-dns/Cargo.toml` *(fails: process interrupted)*
- `cargo check --target x86_64-pc-windows-gnu --manifest-path home-proxy/Cargo.toml` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68948e16d3d08320b8f390237e152d68