### PR TITLE
fix: adjust tauri workflow

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -38,10 +38,6 @@ jobs:
           mkdir -p home-lab/src-tauri/resources
           cp home-dns/target/x86_64-pc-windows-gnu/release/home-dns.exe home-lab/src-tauri/resources/
           cp home-proxy/target/x86_64-pc-windows-gnu/release/home-proxy.exe home-lab/src-tauri/resources/
-      - uses: actions/upload-artifact@v4
-        with:
-          name: installer
-          path: home-lab/src-tauri/target/release/bundle/**/*
       - name: Activer universe et installer dépendances système
         run: |
           sudo apt-get update
@@ -60,8 +56,14 @@ jobs:
           toolchain: stable
 
       - name: Installer dépendances JS
+        working-directory: home-lab
         run: npm ci
 
       - name: Builder Tauri
+        working-directory: home-lab
         run: npm run tauri build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: installer
+          path: home-lab/src-tauri/target/release/bundle/**/*
 


### PR DESCRIPTION
## Summary
- run npm steps from home-lab directory
- upload built bundle after Tauri build

## Testing
- `./bin/actionlint .github/workflows/build-tauri.yml` *(fails: actions-rs/toolchain@v1 runner too old)*

------
https://chatgpt.com/codex/tasks/task_e_68949ba9e0588320835b79a19badaae4