### PR TITLE
Add license and repository metadata to Cargo manifests

### DIFF
--- a/home-dns/Cargo.toml
+++ b/home-dns/Cargo.toml
@@ -2,6 +2,8 @@
 name = "home-dns"
 version = "0.1.0"
 edition = "2024"
+license = "GPL-3.0-only"
+repository = "https://github.com/example/homelab"
 
 [dependencies]
 sysinfo = "0.36.1"

--- a/home-lab/src-tauri/Cargo.toml
+++ b/home-lab/src-tauri/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"
+license = "GPL-3.0-only"
+repository = "https://github.com/example/homelab"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/home-proxy/Cargo.toml
+++ b/home-proxy/Cargo.toml
@@ -2,6 +2,8 @@
 name = "home-proxy"
 version = "0.1.0"
 edition = "2024"
+license = "GPL-3.0-only"
+repository = "https://github.com/example/homelab"
 
 [dependencies]
 sysinfo = "0.36.1"


### PR DESCRIPTION
## Summary
- add license and repository fields to home-dns, home-proxy, and Tauri crate

## Testing
- `cargo check` (home-dns)
- `cargo check` (home-proxy)
- `cargo check` (home-lab/src-tauri) *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894a13107b4832098fdaea3fd9a2505