### PR TITLE
Handle errors in greet invocation

### DIFF
--- a/home-lab/src/main.js
+++ b/home-lab/src/main.js
@@ -5,7 +5,12 @@ let greetMsgEl;
 
 async function greet() {
   // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-  greetMsgEl.textContent = await invoke("greet", { name: greetInputEl.value });
+  try {
+    greetMsgEl.textContent = await invoke("greet", { name: greetInputEl.value });
+  } catch (error) {
+    console.error("Failed to invoke greet command:", error);
+    greetMsgEl.textContent = `Error: ${error}`;
+  }
 }
 
 window.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Summary
- Wrap Tauri `invoke` call in `try`/`catch`
- Show error message in the greeting element when invocation fails

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894a961a690832093b884eebebff142