### PR TITLE
ci: build home-dns binary and verify before copying

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -26,17 +26,26 @@ jobs:
         run: |
           HOST=$(rustc -vV | sed -n 's/^host: //p')
           cargo install cross --git https://github.com/cross-rs/cross --locked --target "$HOST"
-      - name: Build services
+      - name: Build home-proxy service
+        run: cross build --release --target x86_64-pc-windows-gnu --manifest-path home-proxy/Cargo.toml
+      - name: Build home-dns service
         shell: bash
         run: |
-          for crate in home-dns home-proxy; do
-            cross build --release --target x86_64-pc-windows-gnu --manifest-path $crate/Cargo.toml
-          done
+          cross build --release --target x86_64-pc-windows-gnu --manifest-path home-dns/Cargo.toml
+          if [ ! -f home-dns/target/x86_64-pc-windows-gnu/release/home-dns.exe ]; then
+            echo "home-dns.exe not found after build" >&2
+            exit 1
+          fi
       - name: Copy service binaries
         shell: bash
         run: |
           mkdir -p home-lab/src-tauri/resources
-          cp home-dns/target/x86_64-pc-windows-gnu/release/home-dns.exe home-lab/src-tauri/resources/
+          if [ -f home-dns/target/x86_64-pc-windows-gnu/release/home-dns.exe ]; then
+            cp home-dns/target/x86_64-pc-windows-gnu/release/home-dns.exe home-lab/src-tauri/resources/
+          else
+            echo "home-dns.exe not found; aborting copy" >&2
+            exit 1
+          fi
           cp home-proxy/target/x86_64-pc-windows-gnu/release/home-proxy.exe home-lab/src-tauri/resources/
       - name: Activer universe et installer dépendances système
         run: |


### PR DESCRIPTION
## Summary
- build `home-dns` for `x86_64-pc-windows-gnu` before packaging
- ensure `home-dns.exe` exists before copying into resources

## Testing
- `cargo test` *(fails: The system library `gio-2.0` required by crate `gio-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894b3285b488320926259dcff8b6c8e