### PR TITLE
build: adjust tauri workflow for windows

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     env:
       CARGO_TARGET_DIR: target
     steps:
@@ -23,60 +23,30 @@ jobs:
           target: x86_64-pc-windows-gnu
           override: true
       - name: Install cross
+        shell: bash
         run: |
           HOST=$(rustc -vV | sed -n 's/^host: //p')
           cargo install cross --git https://github.com/cross-rs/cross --locked --target "$HOST"
       - name: Build home-proxy service
         env:
           RUSTFLAGS: "-C target-feature=+crt-static"
+        shell: bash
         run: cross build --release --target x86_64-pc-windows-gnu --manifest-path home-proxy/Cargo.toml
       - name: Build home-dns service
         env:
           RUSTFLAGS: "-C target-feature=+crt-static"
         shell: bash
-        run: |
-          cross build --release --target x86_64-pc-windows-gnu --manifest-path home-dns/Cargo.toml
-          if [ ! -f target/x86_64-pc-windows-gnu/release/home-dns.exe ]; then
-            echo "home-dns.exe not found after build" >&2
-            exit 1
-          fi
+        run: cross build --release --target x86_64-pc-windows-gnu --manifest-path home-dns/Cargo.toml
       - name: Copy service binaries
         shell: bash
         run: |
           mkdir -p home-lab/src-tauri/resources
-          if [ -f target/x86_64-pc-windows-gnu/release/home-dns.exe ]; then
-            cp target/x86_64-pc-windows-gnu/release/home-dns.exe home-lab/src-tauri/resources/
-          else
-            echo "home-dns.exe not found; aborting copy" >&2
-            exit 1
-          fi
           cp target/x86_64-pc-windows-gnu/release/home-proxy.exe home-lab/src-tauri/resources/
-      - name: Activer universe et installer dépendances système
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y software-properties-common
-          sudo add-apt-repository universe
-          sudo apt-get update
-          sudo apt-get install -y \
-            pkg-config \
-            libglib2.0-dev \
-            libgtk-3-dev \
-            libwebkit2gtk-4.1-dev
-
-      - name: Installer toolchain Rust
-        uses: actions-rs/toolchain@v1
+          cp target/x86_64-pc-windows-gnu/release/home-dns.exe home-lab/src-tauri/resources/
+      - uses: tauri-apps/tauri-action@v1
         with:
-          toolchain: stable
-
-      - name: Installer dépendances JS
-        working-directory: home-lab
-        run: npm ci
-
-      - name: Builder Tauri
-        env:
-          RUSTFLAGS: ""
-        working-directory: home-lab
-        run: npm run tauri build
+          projectPath: ./home-lab
+          args: build
       - uses: actions/upload-artifact@v4
         with:
           name: installer


### PR DESCRIPTION
## Summary
- build Tauri app only on Windows runner
- cross-compile home-proxy and home-dns for Windows
- use tauri-action and upload installer artifact

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6895994354c483208102c57906a781a4