### PR TITLE
feat: add tray plugin with basic menu and events

### DIFF
--- a/home-lab/src-tauri/Cargo.toml
+++ b/home-lab/src-tauri/Cargo.toml
@@ -20,5 +20,6 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-tray = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/home-lab/src-tauri/src/lib.rs
+++ b/home-lab/src-tauri/src/lib.rs
@@ -8,6 +8,30 @@ fn greet(name: &str) -> String {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_tray::init())
+        .setup(|app| {
+            use tauri::menu::{MenuBuilder, MenuItem};
+            use tauri_plugin_tray::{TrayIconBuilder, TrayIconEvent};
+
+            let app_handle = app.app_handle();
+
+            let quit = MenuItem::with_id(app_handle.clone(), "quit", "Quit", true, None);
+            let menu = MenuBuilder::new(app_handle.clone())
+                .item(&quit)
+                .build()?;
+
+            TrayIconBuilder::new()
+                .icon(app_handle.default_window_icon().unwrap().clone())
+                .menu(&menu)
+                .on_event(|_, event| match event {
+                    TrayIconEvent::Enter { .. } => println!("tray hover"),
+                    TrayIconEvent::DoubleClick { .. } => println!("tray double click"),
+                    _ => {}
+                })
+                .build(app_handle.clone())?;
+
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![greet])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## Summary
- add `tauri-plugin-tray` dependency
- set up tray icon, menu and basic hover and double-click events

## Testing
- `cargo test` *(fails: no matching package named `tauri-plugin-tray` found)*

------
https://chatgpt.com/codex/tasks/task_e_689791e930608320b966d5e478514b6f