### PR TITLE
chore(home-lab): use built-in tray icon

### DIFF
--- a/home-lab/src-tauri/Cargo.toml
+++ b/home-lab/src-tauri/Cargo.toml
@@ -14,12 +14,12 @@ edition = "2021"
 name = "home_lab_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+
 [build-dependencies]
-tauri-build = { version = "2", features = [] }
+tauri-build = { version = "2" }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
-tauri-plugin-tray = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/home-lab/src-tauri/src/lib.rs
+++ b/home-lab/src-tauri/src/lib.rs
@@ -8,27 +8,27 @@ fn greet(name: &str) -> String {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .plugin(tauri_plugin_tray::init())
         .setup(|app| {
             use tauri::menu::{MenuBuilder, MenuItem};
-            use tauri_plugin_tray::{TrayIconBuilder, TrayIconEvent};
+            use tauri::tray::{TrayIconBuilder, TrayIconEvent};
+            use tauri::Manager;
 
             let app_handle = app.app_handle();
 
-            let quit = MenuItem::with_id(app_handle.clone(), "quit", "Quit", true, None);
-            let menu = MenuBuilder::new(app_handle.clone())
+            let quit = MenuItem::with_id(app_handle, "quit", "Quit", true, None::<&str>)?;
+            let menu = MenuBuilder::new(app_handle)
                 .item(&quit)
                 .build()?;
 
             TrayIconBuilder::new()
                 .icon(app_handle.default_window_icon().unwrap().clone())
                 .menu(&menu)
-                .on_event(|_, event| match event {
+                .on_tray_icon_event(|_, event| match event {
                     TrayIconEvent::Enter { .. } => println!("tray hover"),
                     TrayIconEvent::DoubleClick { .. } => println!("tray double click"),
                     _ => {}
                 })
-                .build(app_handle.clone())?;
+                .build(app_handle)?;
 
             Ok(())
         })


### PR DESCRIPTION
## Summary
- remove tray plugin dependency and enable built-in tray icon feature
- initialize tray icon via `tauri::tray` instead of plugin

## Testing
- `cargo check -p home-lab`

------
https://chatgpt.com/codex/tasks/task_e_68979c0d233c83208a281c5e7c0ed390