### PR TITLE
feat(tray): open history on double click

### DIFF
--- a/home-lab/.gitignore
+++ b/home-lab/.gitignore
@@ -6,6 +6,9 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+!src-tauri/resources/logs/
+!src-tauri/resources/logs/*.log
+!src-tauri/resources/logs/*.log
 
 node_modules
 dist

--- a/home-lab/src-tauri/resources/logs/dns.log
+++ b/home-lab/src-tauri/resources/logs/dns.log
@@ -1,0 +1,2 @@
+2024-01-01T00:00:00Z DNS service started
+2024-01-01T01:00:00Z Query handled for example.com

--- a/home-lab/src-tauri/resources/logs/https.log
+++ b/home-lab/src-tauri/resources/logs/https.log
@@ -1,0 +1,2 @@
+2024-01-01T00:00:00Z HTTPS proxy initialized
+2024-01-01T02:30:00Z Certificate renewed

--- a/home-lab/src-tauri/resources/logs/k3s.log
+++ b/home-lab/src-tauri/resources/logs/k3s.log
@@ -1,0 +1,2 @@
+2024-01-01T00:00:00Z k3s cluster booted
+2024-01-01T03:45:00Z Node joined the cluster

--- a/home-lab/src/history.html
+++ b/home-lab/src/history.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Service History</title>
+</head>
+<body>
+  <pre id="log"></pre>
+  <script type="module">
+    const { invoke } = window.__TAURI__.core;
+    const params = new URLSearchParams(window.location.search);
+    const service = params.get("service") || "";
+    async function load() {
+      try {
+        const content = await invoke("read_service_log", { service });
+        document.getElementById("log").textContent = content;
+      } catch (e) {
+        document.getElementById("log").textContent = `Error: ${e}`;
+      }
+    }
+    load();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- open dedicated history window when double-clicking service tray icons
- add command to read service logs and connect dashboard to log files
- include sample log files for services

## Testing
- `cargo test` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898507c8ac88320adb53c9c1162c6b0