### PR TITLE
feat: enable PNG icon support for Tauri

### DIFF
--- a/home-lab/src-tauri/Cargo.toml
+++ b/home-lab/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2" }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon"] }
+tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## Summary
- enable PNG icon support in Tauri build

## Testing
- `cargo build` *(fails: The system library `libsoup-3.0` required by crate `soup3-sys` was not found.)*


------
https://chatgpt.com/codex/tasks/task_e_6898a481b46083209847545dbb201db6