### PR TITLE
refactor: adjust MenuEvent import path

### DIFF
--- a/home-lab/src-tauri/src/lib.rs
+++ b/home-lab/src-tauri/src/lib.rs
@@ -68,8 +68,9 @@ pub fn run() {
 
             use tauri::image::Image;
             use tauri::menu::{MenuBuilder, MenuItem, SubmenuBuilder};
+            use tauri::menu::MenuEvent;
             use tauri::path::BaseDirectory;
-            use tauri::tray::{MenuEvent, TrayIcon, TrayIconBuilder, TrayIconEvent};
+            use tauri::tray::{TrayIcon, TrayIconBuilder, TrayIconEvent};
             use tauri::Manager;
 
             let app_handle = app.app_handle();


### PR DESCRIPTION
## Summary
- import `MenuEvent` from `tauri::menu`

## Testing
- `cargo test` *(fails: resource path `resources/home-dns.exe` doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_6898b128a7bc83208696c02d337c80bc