### PR TITLE
Import tauri Manager and Emitter traits globally

### DIFF
--- a/home-lab/src-tauri/src/lib.rs
+++ b/home-lab/src-tauri/src/lib.rs
@@ -1,4 +1,6 @@
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
+use tauri::{Emitter, Manager};
+
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
@@ -71,7 +73,6 @@ pub fn run() {
             use tauri::menu::MenuEvent;
             use tauri::path::BaseDirectory;
             use tauri::tray::{TrayIcon, TrayIconBuilder, TrayIconEvent};
-            use tauri::Manager;
 
             let app_handle = app.app_handle();
             let resolver = app_handle.path();


### PR DESCRIPTION
## Summary
- expose tauri's `Manager` and `Emitter` traits at the crate root
- clean up redundant `Manager` import within the `setup` closure

## Testing
- `cargo check -p home-lab` *(fails: The system library `gio-2.0` required by crate `gio-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898b7120d248320b6220b2a78f9b126