### PR TITLE
ci: include docker image in tauri windows build

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -60,7 +60,7 @@ jobs:
   # === OPTION RECOMMANDÉE: installateur Windows officiel (runner Windows) ===
   build-tauri-win:
     runs-on: windows-latest
-    needs: build-services
+    needs: [build-services, build-docker-image]
     steps:
       - uses: actions/checkout@v5
 
@@ -69,6 +69,15 @@ jobs:
         with:
           name: services-win
           path: home-lab/src-tauri/resources
+
+      - name: Download Docker image into Tauri resources
+        uses: actions/download-artifact@v5
+        with:
+          name: env-dev-image.tar
+          path: home-lab/src-tauri/resources
+
+      - name: Rename Docker image
+        run: mv home-lab/src-tauri/resources/env-dev-image.tar home-lab/src-tauri/resources/homelab-img.tar
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- include docker image artifact in Windows build

## Testing
- `cargo test` *(fails: rustc 1.87.0 is not supported by sysinfo@0.37.0)*
- `gh workflow run build-tauri.yml` *(fails: not authenticated)*

------
https://chatgpt.com/codex/tasks/task_e_68a082831d648320a6485aae83662f75