### PR TITLE
chore: move service binaries into bin for tauri

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -64,11 +64,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Download services artifacts into Tauri resources
+      - name: Download services artifacts into Tauri bin
         uses: actions/download-artifact@v5
         with:
           name: services-win
-          path: home-lab/src-tauri/resources
+          path: home-lab/src-tauri/bin
 
       - name: Download Docker image into Tauri resources
         uses: actions/download-artifact@v5

--- a/home-lab/src-tauri/tauri.conf.json
+++ b/home-lab/src-tauri/tauri.conf.json
@@ -36,9 +36,11 @@
     ],
     "resources": [
        "resources/conf/*",
-      "resources/home-dns.exe",
-      "resources/home-proxy.exe",
       "icons/**/*"
+    ],
+    "externalBin": [
+      "bin/home-dns.exe",
+      "bin/home-proxy.exe"
     ],
     "windows": {
       "nsis": {


### PR DESCRIPTION
## Summary
- download service artifacts into `src-tauri/bin`
- list service executables via `bundle.externalBin`

## Testing
- `cargo test` *(fails: The system library `gio-2.0` required by crate `gio-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a18b8415208320ad2f483347a89ced