### PR TITLE
Rename Windows service binaries for Tauri bundler

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -70,6 +70,12 @@ jobs:
           name: services-win
           path: home-lab/src-tauri/bin
 
+      - name: Rename service binaries for Tauri bundler
+        shell: pwsh
+        run: |
+          Rename-Item -Path home-lab/src-tauri/bin/home-dns.exe -NewName home-dns.exe-x86_64-pc-windows-msvc.exe
+          Rename-Item -Path home-lab/src-tauri/bin/home-proxy.exe -NewName home-proxy.exe-x86_64-pc-windows-msvc.exe
+
       - name: Download Docker image into Tauri resources
         uses: actions/download-artifact@v5
         with:


### PR DESCRIPTION
## Summary
- Rename downloaded Windows service binaries with `x86_64-pc-windows-msvc` suffix so Tauri bundles them correctly

## Testing
- `npx tauri build --target x86_64-pc-windows-msvc` *(fails: linker `link.exe` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c5c5670c832092deaf56f488b009