### PR TITLE
fix: include conf directory in bundle

### DIFF
--- a/home-lab/src-tauri/tauri.conf.json
+++ b/home-lab/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
       "icons/icon.ico"
     ],
     "resources": [
-       "resources/conf/*",
+       "resources/conf",
       "icons/**/*"
     ],
     "externalBin": [


### PR DESCRIPTION
## Summary
- package: copy full conf directory instead of glob

## Testing
- `npm run tauri build` *(fails: The system library `gdk-3.0` required by crate `gdk-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a230c22c488320975d5b31360dd01c