### PR TITLE
feat: add http config and installer support

### DIFF
--- a/home-lab/src-tauri/resources/conf/http.yaml
+++ b/home-lab/src-tauri/resources/conf/http.yaml
@@ -1,0 +1,8 @@
+http: 80
+https: 443
+wsl_resolve: "auto"
+# wsl_ip: "172.29.96.1"
+wsl_refresh_secs: 30
+routes: {}
+log_level: "info"
+

--- a/home-lab/src-tauri/resources/install-services.nsh
+++ b/home-lab/src-tauri/resources/install-services.nsh
@@ -4,6 +4,10 @@
     ; Si, pour une raison X, la ressource n'a pas été copiée :
     CopyFiles /SILENT "$INSTDIR\dns.yaml" "$INSTDIR\conf\dns.yaml"
   ${EndIf}
+  ${IfNot} ${FileExists} "$INSTDIR\conf\http.yaml"
+    ; Si, pour une raison X, la ressource n'a pas été copiée :
+    CopyFiles /SILENT "$INSTDIR\http.yaml" "$INSTDIR\conf\http.yaml"
+  ${EndIf}
   nsExec::Exec '"$INSTDIR\\home-dns.exe" install'
   nsExec::Exec '"$INSTDIR\\home-proxy.exe" install'
     ; Exécution après installation

--- a/home-lab/src-tauri/resources/install-services.wxi
+++ b/home-lab/src-tauri/resources/install-services.wxi
@@ -31,12 +31,21 @@
             Vital="yes"/>
     </Component>
 
+      <Component Id="CmpHttpYaml" Guid="*" Directory="ConfDir" NeverOverwrite="yes">
+        <CreateFolder/>
+        <File Id="FileHttpYaml"
+              Source="$(var.SourceDir)conf\\http.yaml"
+              KeyPath="yes"
+              Vital="yes"/>
+      </Component>
+
     <!-- Groupe pour raccorder à la Feature -->
     <ComponentGroup Id="AppAllComponents">
       <ComponentRef Id="CmpHomeDns"/>
       <ComponentRef Id="CmpHomeProxy"/>
       <ComponentRef Id="CmpDnsYaml"/>
-    </ComponentGroup>
+      <ComponentRef Id="CmpHttpYaml"/>
+      </ComponentGroup>
   </Fragment>
 
   <!-- Extension de la Feature principale générée par Tauri -->


### PR DESCRIPTION
## Summary
- add default http proxy configuration
- install http.yaml alongside dns.yaml
- include http.yaml in WiX component group

## Testing
- `cargo test` *(fails: could not find `windows` in `net`)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cdd833f8832084bc6192b90fde0d