### PR TITLE
Handle Tauri run errors with Windows dialog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,6 +1563,7 @@ dependencies = [
  "tonic-build 0.11.0",
  "tower 0.5.2",
  "usvg",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/home-lab/README.md
+++ b/home-lab/README.md
@@ -5,3 +5,7 @@ This template should help get you started developing with Tauri in vanilla HTML,
 ## Recommended IDE Setup
 
 - [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+
+## Windows requirements
+
+Startup errors use the modern `TaskDialogIndirect` API when it is available (Windows Vista or newer). If the function is missing, the application falls back to `MessageBoxW`, so it can still display an error on older versions of Windows. Without this fallback, Windows Vista would be the minimum supported version.

--- a/home-lab/src-tauri/Cargo.toml
+++ b/home-lab/src-tauri/Cargo.toml
@@ -34,3 +34,11 @@ png = "0.17"
 tonic-build = "0.11"
 prost-build = "0.12"
 protoc-bin-vendored = "3"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_System_LibraryLoader",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_Controls_Dialogs",
+] }


### PR DESCRIPTION
## Summary
- Show startup errors using TaskDialogIndirect when available on Windows, with a fallback to MessageBoxW
- Document Windows version requirements and add windows-sys dependency

## Testing
- `cargo check -p homelab-tauri --target x86_64-pc-windows-gnu`

------
https://chatgpt.com/codex/tasks/task_e_68a75ec255a08320a706d3db36588f01