### PR TITLE
feat: add Windows manifest for Tauri

### DIFF
--- a/home-lab/src-tauri/resources/app.manifest
+++ b/home-lab/src-tauri/resources/app.manifest
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32"
+                        name="Microsoft.Windows.Common-Controls"
+                        version="6.0.0.0"
+                        processorArchitecture="*"
+                        publicKeyToken="6595b64144ccf1df"
+                        language="*"/>
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/home-lab/src-tauri/tauri.conf.json
+++ b/home-lab/src-tauri/tauri.conf.json
@@ -45,6 +45,7 @@
      
     ],
     "windows": {
+      "manifest": "resources/app.manifest",
       "nsis": {
         "installMode": "perMachine",
         "installerHooks": "resources/install-services.nsh"


### PR DESCRIPTION
## Summary
- add Windows common-controls manifest
- reference manifest in Tauri bundler config

## Testing
- `npm run -w frontend build`
- `cargo build --release --workspace` *(fails: unknown field `manifest` and Windows-specific modules)*
- `cargo build --release -p home-dns -p home-proxy --target x86_64-pc-windows-gnu` *(fails: missing dlltool)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fd79c40c8320bc6c9ce7bd1636f0