### PR TITLE
Ensure log directory exists for Tauri

### DIFF
--- a/home-lab/src-tauri/src/lib.rs
+++ b/home-lab/src-tauri/src/lib.rs
@@ -134,6 +134,10 @@ pub fn run() {
         .join("home-lab")
         .join("logs");
 
+    if let Err(e) = std::fs::create_dir_all(&log_dir) {
+        eprintln!("failed to create log directory {}: {e}", log_dir.display());
+    }
+
     if let Err(err) = tauri::Builder::default()
         .plugin(
             tauri_plugin_log::Builder::new()


### PR DESCRIPTION
## Summary
- Create log directory before starting Tauri and print any creation errors

## Testing
- `cargo test -p homelab-tauri` *(fails: could not find `windows` in `net`)*

------
https://chatgpt.com/codex/tasks/task_e_68a819e9644c8320b0ae56e7f5235ec3