### PR TITLE
Prefix HTTP and DNS Tauri command names for uniqueness

### DIFF
--- a/home-lab/src-tauri/src/dns.rs
+++ b/home-lab/src-tauri/src/dns.rs
@@ -70,10 +70,10 @@ struct RecordOut { name: String, a: Vec<String>, aaaa: Vec<String>, ttl: u32 }
 struct ListRecordsOut { records: Vec<RecordOut> }
 
 #[tauri::command]
-async fn ping() -> String { "pong".into() }
+async fn dns_ping() -> String { "pong".into() }
 
 #[tauri::command]
-pub async fn get_status() -> Result<StatusOut, String> {
+pub async fn dns_get_status() -> Result<StatusOut, String> {
     let ch = dns_make_channel().await.map_err(map_err)?;
     let mut client = HomeDnsClient::new(ch);
     let resp = client.get_status(tonic::Request::new(Empty{})).await.map_err(map_err)?;
@@ -82,7 +82,7 @@ pub async fn get_status() -> Result<StatusOut, String> {
 }
 
 #[tauri::command]
-pub async fn stop_service() -> Result<AckOut, String> {
+pub async fn dns_stop_service() -> Result<AckOut, String> {
     let ch = dns_make_channel().await.map_err(map_err)?;
     let mut client = HomeDnsClient::new(ch);
     let resp = client.stop_service(tonic::Request::new(Empty{})).await.map_err(map_err)?;
@@ -91,7 +91,7 @@ pub async fn stop_service() -> Result<AckOut, String> {
 }
 
 #[tauri::command]
-pub async fn reload_config() -> Result<AckOut, String> {
+pub async fn dns_reload_config() -> Result<AckOut, String> {
     let ch = dns_make_channel().await.map_err(map_err)?;
     let mut client = HomeDnsClient::new(ch);
     let resp = client.reload_config(tonic::Request::new(Empty{})).await.map_err(map_err)?;
@@ -100,7 +100,7 @@ pub async fn reload_config() -> Result<AckOut, String> {
 }
 
 #[tauri::command]
-pub async fn list_records() -> Result<ListRecordsOut, String> {
+pub async fn dns_list_records() -> Result<ListRecordsOut, String> {
     let ch = dns_make_channel().await.map_err(map_err)?;
     let mut client = HomeDnsClient::new(ch);
     let resp = client.list_records(tonic::Request::new(Empty{})).await.map_err(map_err)?;
@@ -114,7 +114,7 @@ pub async fn list_records() -> Result<ListRecordsOut, String> {
 }
 
 #[tauri::command]
-pub async fn add_record(name: String, rrtype: String, value: String, ttl: u32) -> Result<AckOut, String> {
+pub async fn dns_add_record(name: String, rrtype: String, value: String, ttl: u32) -> Result<AckOut, String> {
     let ch = dns_make_channel().await.map_err(map_err)?;
     let mut client = HomeDnsClient::new(ch);
     let req = AddRecordRequest { name, rrtype, value, ttl };
@@ -124,7 +124,7 @@ pub async fn add_record(name: String, rrtype: String, value: String, ttl: u32) -
 }
 
 #[tauri::command]
-pub async fn remove_record(name: String, rrtype: String, value: String) -> Result<AckOut, String> {
+pub async fn dns_remove_record(name: String, rrtype: String, value: String) -> Result<AckOut, String> {
     let ch = dns_make_channel().await.map_err(map_err)?;
     let mut client = HomeDnsClient::new(ch);
     let req = RemoveRecordRequest { name, rrtype, value };

--- a/home-lab/src-tauri/src/http.rs
+++ b/home-lab/src-tauri/src/http.rs
@@ -43,36 +43,36 @@ pub struct RouteOut { pub host: String, pub port: u32 }
 pub struct ListRoutesOut { pub routes: Vec<RouteOut> }
 
 #[tauri::command]
-pub async fn get_status() -> Result<StatusOut, String> {
+pub async fn http_get_status() -> Result<StatusOut, String> {
     let ch = http_make_channel().await.map_err(map_err)?;
-    let mut client = HomehttpClient::new(ch);
+    let mut client = HomeHttpClient::new(ch);
     let resp = client.get_status(Empty{}).await.map_err(map_err)?;
     let s = resp.into_inner();
     Ok(StatusOut { state: s.state, log_level: s.log_level })
 }
 
 #[tauri::command]
-pub async fn reload_config() -> Result<AckOut, String> {
+pub async fn http_reload_config() -> Result<AckOut, String> {
     let ch = http_make_channel().await.map_err(map_err)?;
-    let mut client = HomehttpClient::new(ch);
+    let mut client = HomeHttpClient::new(ch);
     let resp = client.reload_config(Empty{}).await.map_err(map_err)?;
     let a = resp.into_inner();
     Ok(AckOut { ok: a.ok, message: a.message })
 }
 
 #[tauri::command]
-pub async fn stop_service() -> Result<AckOut, String> {
+pub async fn http_stop_service() -> Result<AckOut, String> {
     let ch = http_make_channel().await.map_err(map_err)?;
-    let mut client = HomehttpClient::new(ch);
+    let mut client = HomeHttpClient::new(ch);
     let resp = client.stop_service(Empty{}).await.map_err(map_err)?;
     let a = resp.into_inner();
     Ok(AckOut { ok: a.ok, message: a.message })
 }
 
 #[tauri::command]
-pub async fn list_routes() -> Result<ListRoutesOut, String> {
+pub async fn http_list_routes() -> Result<ListRoutesOut, String> {
     let ch = http_make_channel().await.map_err(map_err)?;
-    let mut client = HomehttpClient::new(ch);
+    let mut client = HomeHttpClient::new(ch);
     let resp = client.list_routes(Empty{}).await.map_err(map_err)?;
     let list = resp.into_inner();
     Ok(ListRoutesOut {
@@ -81,9 +81,9 @@ pub async fn list_routes() -> Result<ListRoutesOut, String> {
 }
 
 #[tauri::command]
-pub async fn add_route(host: String, port: u32) -> Result<AckOut, String> {
+pub async fn http_add_route(host: String, port: u32) -> Result<AckOut, String> {
     let ch = http_make_channel().await.map_err(map_err)?;
-    let mut client = HomehttpClient::new(ch);
+    let mut client = HomeHttpClient::new(ch);
     let req = AddRouteRequest { host, port };
     let resp = client.add_route(req).await.map_err(map_err)?;
     let a = resp.into_inner();
@@ -91,7 +91,7 @@ pub async fn add_route(host: String, port: u32) -> Result<AckOut, String> {
 }
 
 #[tauri::command]
-pub async fn remove_route(host: String) -> Result<AckOut, String> {
+pub async fn http_remove_route(host: String) -> Result<AckOut, String> {
     let ch = http_make_channel().await.map_err(map_err)?;
     let mut client = HomeHttpClient::new(ch);
     let req = RemoveRouteRequest { host };

--- a/home-lab/src-tauri/src/lib.rs
+++ b/home-lab/src-tauri/src/lib.rs
@@ -81,18 +81,18 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             // Tes handlers d’origine :
 
-            dns::get_status,
-            dns::stop_service,
-            dns::reload_config,
-            dns::list_records,
-            dns::add_record,
-            dns::remove_record,
-            http::get_status,
-            http::stop_service,
-            http::reload_config,
-            http::list_routes,
-            http::add_route,
-            http::remove_route,
+            dns::dns_get_status,
+            dns::dns_stop_service,
+            dns::dns_reload_config,
+            dns::dns_list_records,
+            dns::dns_add_record,
+            dns::dns_remove_record,
+            http::http_get_status,
+            http::http_stop_service,
+            http::http_reload_config,
+            http::http_list_routes,
+            http::http_add_route,
+            http::http_remove_route,
    
         ])
         .run(tauri::generate_context!())


### PR DESCRIPTION
## Summary
- Prefix HTTP and DNS Tauri command handlers with service identifiers
- Register renamed handlers in `invoke_handler` to avoid cross-service name collisions
- Use the correct `HomeHttpClient` type for HTTP service communication

## Testing
- `cargo test` *(fails: rustc 1.87.0 unsupported by sysinfo 0.37.0)*
- `npm test` *(fails: Missing script "test")*
- `npm run build:frontend`


------
https://chatgpt.com/codex/tasks/task_e_68aaad5bb9a083208017dac57b648bf7