### PR TITLE
Add toast component for error handling

### DIFF
--- a/home-lab/README.md
+++ b/home-lab/README.md
@@ -15,3 +15,4 @@ npm run tauri dev  # start Tauri desktop app
 - `<dns-records>`: shows available DNS records.
 - `<http-status>`: displays the HTTP service state and log level.
 - `<http-routes>`: shows configured HTTP routes.
+- `<toast-container>`: hosts transient error messages; use `showError(message)` to display a toast.

--- a/home-lab/index.html
+++ b/home-lab/index.html
@@ -11,6 +11,7 @@
     <dns-records></dns-records>
     <http-status></http-status>
     <http-routes></http-routes>
+    <toast-container></toast-container>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/home-lab/src/components/dns-records.js
+++ b/home-lab/src/components/dns-records.js
@@ -5,14 +5,18 @@ class DnsRecords extends HTMLElement {
     this.render();
   }
   async render() {
-    const records = await dns_list_records();
-    this.innerHTML = `
+    try {
+      const records = await dns_list_records();
+      this.innerHTML = `
       <div class="p-4 bg-gray-100 rounded">
         <h2 class="font-bold mb-2">DNS Records</h2>
         <ul class="list-disc pl-5">
           ${records.map(r => `<li>${JSON.stringify(r)}</li>`).join('')}
         </ul>
       </div>`;
+    } catch (err) {
+      showError(err.message);
+    }
   }
 }
 

--- a/home-lab/src/components/dns-status.js
+++ b/home-lab/src/components/dns-status.js
@@ -5,13 +5,17 @@ class DnsStatus extends HTMLElement {
     this.render();
   }
   async render() {
-    const status = await dns_get_status();
-    this.innerHTML = `
+    try {
+      const status = await dns_get_status();
+      this.innerHTML = `
       <div class="p-4 bg-gray-100 rounded">
         <h2 class="font-bold mb-2">DNS Status</h2>
         <p>State: ${status.state}</p>
         <p>Log level: ${status.log_level}</p>
       </div>`;
+    } catch (err) {
+      showError(err.message);
+    }
   }
 }
 

--- a/home-lab/src/components/http-routes.js
+++ b/home-lab/src/components/http-routes.js
@@ -5,14 +5,18 @@ class HttpRoutes extends HTMLElement {
     this.render();
   }
   async render() {
-    const routes = await http_list_routes();
-    this.innerHTML = `
+    try {
+      const routes = await http_list_routes();
+      this.innerHTML = `
       <div class="p-4 bg-gray-100 rounded">
         <h2 class="font-bold mb-2">HTTP Routes</h2>
         <ul class="list-disc pl-5">
           ${routes.map(r => `<li>${JSON.stringify(r)}</li>`).join('')}
         </ul>
       </div>`;
+    } catch (err) {
+      showError(err.message);
+    }
   }
 }
 

--- a/home-lab/src/components/http-status.js
+++ b/home-lab/src/components/http-status.js
@@ -5,13 +5,17 @@ class HttpStatus extends HTMLElement {
     this.render();
   }
   async render() {
-    const status = await http_get_status();
-    this.innerHTML = `
+    try {
+      const status = await http_get_status();
+      this.innerHTML = `
       <div class="p-4 bg-gray-100 rounded">
         <h2 class="font-bold mb-2">HTTP Status</h2>
         <p>State: ${status.state}</p>
         <p>Log level: ${status.log_level}</p>
       </div>`;
+    } catch (err) {
+      showError(err.message);
+    }
   }
 }
 

--- a/home-lab/src/components/toast.js
+++ b/home-lab/src/components/toast.js
@@ -1,0 +1,20 @@
+class ToastContainer extends HTMLElement {
+  connectedCallback() {
+    this.className = 'fixed top-4 right-4 space-y-2 z-50';
+  }
+  show(message) {
+    const toast = document.createElement('div');
+    toast.textContent = message;
+    toast.className = 'bg-red-500 text-white px-4 py-2 rounded shadow';
+    this.appendChild(toast);
+    setTimeout(() => toast.remove(), 3000);
+  }
+}
+
+customElements.define('toast-container', ToastContainer);
+
+export function showError(message) {
+  document.querySelector('toast-container')?.show(message);
+}
+
+globalThis.showError = showError;

--- a/home-lab/src/main.js
+++ b/home-lab/src/main.js
@@ -1,4 +1,5 @@
 import './style.css';
+import './components/toast.js';
 import './components/dns-status.js';
 import './components/dns-records.js';
 import './components/http-status.js';


### PR DESCRIPTION
## Summary
- add toast-container custom element and global `showError`
- wrap backend calls in try/catch to show toast on failure
- document toast component and include in app entry

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b29f5d69648320b7c8b2e6c7fe4734