### PR TITLE
feat: add safe invoke utility

### DIFF
--- a/home-lab/src/tauri.js
+++ b/home-lab/src/tauri.js
@@ -1,49 +1,56 @@
 import { invoke } from '@tauri-apps/api/core';
 
+export function safeInvoke(cmd, args) {
+  if (!window.__TAURI__?.invoke) {
+    return Promise.reject(new Error('Tauri API not available'));
+  }
+  return invoke(cmd, args);
+}
+
 export async function dns_get_status() {
-  return invoke('dns_get_status');
+  return safeInvoke('dns_get_status');
 }
 
 export async function dns_stop_service() {
-  return invoke('dns_stop_service');
+  return safeInvoke('dns_stop_service');
 }
 
 export async function dns_reload_config() {
-  return invoke('dns_reload_config');
+  return safeInvoke('dns_reload_config');
 }
 
 export async function dns_list_records() {
-  return invoke('dns_list_records');
+  return safeInvoke('dns_list_records');
 }
 
 export async function dns_add_record(record) {
-  return invoke('dns_add_record', { record });
+  return safeInvoke('dns_add_record', { record });
 }
 
 export async function dns_remove_record(id) {
-  return invoke('dns_remove_record', { id });
+  return safeInvoke('dns_remove_record', { id });
 }
 
 export async function http_get_status() {
-  return invoke('http_get_status');
+  return safeInvoke('http_get_status');
 }
 
 export async function http_stop_service() {
-  return invoke('http_stop_service');
+  return safeInvoke('http_stop_service');
 }
 
 export async function http_reload_config() {
-  return invoke('http_reload_config');
+  return safeInvoke('http_reload_config');
 }
 
 export async function http_list_routes() {
-  return invoke('http_list_routes');
+  return safeInvoke('http_list_routes');
 }
 
 export async function http_add_route(route) {
-  return invoke('http_add_route', { route });
+  return safeInvoke('http_add_route', { route });
 }
 
 export async function http_remove_route(id) {
-  return invoke('http_remove_route', { id });
+  return safeInvoke('http_remove_route', { id });
 }


### PR DESCRIPTION
## Summary
- add safeInvoke wrapper to check Tauri API availability
- switch Tauri command helpers to use safeInvoke

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b2a19528488320a95480478b025f2a