### PR TITLE
feat: avoid Tauri calls outside environment

### DIFF
--- a/home-lab/src/components/dns-records.js
+++ b/home-lab/src/components/dns-records.js
@@ -1,10 +1,18 @@
-import { dns_list_records } from '../tauri.js';
+import { dns_list_records, isTauri } from '../tauri.js';
 
 class DnsRecords extends HTMLElement {
   connectedCallback() {
     this.render();
   }
   async render() {
+    if (!isTauri()) {
+      this.innerHTML = `
+      <div class="p-4 bg-gray-100 rounded">
+        <h2 class="font-bold mb-2">DNS Records</h2>
+        <p>Tauri API not available. Please run via Tauri.</p>
+      </div>`;
+      return;
+    }
     try {
       const records = await dns_list_records();
       this.innerHTML = `

--- a/home-lab/src/components/dns-status.js
+++ b/home-lab/src/components/dns-status.js
@@ -1,10 +1,18 @@
-import { dns_get_status } from '../tauri.js';
+import { dns_get_status, isTauri } from '../tauri.js';
 
 class DnsStatus extends HTMLElement {
   connectedCallback() {
     this.render();
   }
   async render() {
+    if (!isTauri()) {
+      this.innerHTML = `
+      <div class="p-4 bg-gray-100 rounded">
+        <h2 class="font-bold mb-2">DNS Status</h2>
+        <p>Tauri API not available. Please run via Tauri.</p>
+      </div>`;
+      return;
+    }
     try {
       const status = await dns_get_status();
       this.innerHTML = `

--- a/home-lab/src/components/http-routes.js
+++ b/home-lab/src/components/http-routes.js
@@ -1,10 +1,18 @@
-import { http_list_routes } from '../tauri.js';
+import { http_list_routes, isTauri } from '../tauri.js';
 
 class HttpRoutes extends HTMLElement {
   connectedCallback() {
     this.render();
   }
   async render() {
+    if (!isTauri()) {
+      this.innerHTML = `
+      <div class="p-4 bg-gray-100 rounded">
+        <h2 class="font-bold mb-2">HTTP Routes</h2>
+        <p>Tauri API not available. Please run via Tauri.</p>
+      </div>`;
+      return;
+    }
     try {
       const routes = await http_list_routes();
       this.innerHTML = `

--- a/home-lab/src/components/http-status.js
+++ b/home-lab/src/components/http-status.js
@@ -1,10 +1,18 @@
-import { http_get_status } from '../tauri.js';
+import { http_get_status, isTauri } from '../tauri.js';
 
 class HttpStatus extends HTMLElement {
   connectedCallback() {
     this.render();
   }
   async render() {
+    if (!isTauri()) {
+      this.innerHTML = `
+      <div class="p-4 bg-gray-100 rounded">
+        <h2 class="font-bold mb-2">HTTP Status</h2>
+        <p>Tauri API not available. Please run via Tauri.</p>
+      </div>`;
+      return;
+    }
     try {
       const status = await http_get_status();
       this.innerHTML = `

--- a/home-lab/src/tauri.js
+++ b/home-lab/src/tauri.js
@@ -1,49 +1,60 @@
 import { invoke } from '@tauri-apps/api/core';
 
+export function isTauri() {
+  return Boolean(window.__TAURI__?.invoke);
+}
+
+export function safeInvoke(cmd, args) {
+  if (!isTauri()) {
+    return Promise.reject(new Error('Tauri API not available'));
+  }
+  return invoke(cmd, args);
+}
+
 export async function dns_get_status() {
-  return invoke('dns_get_status');
+  return safeInvoke('dns_get_status');
 }
 
 export async function dns_stop_service() {
-  return invoke('dns_stop_service');
+  return safeInvoke('dns_stop_service');
 }
 
 export async function dns_reload_config() {
-  return invoke('dns_reload_config');
+  return safeInvoke('dns_reload_config');
 }
 
 export async function dns_list_records() {
-  return invoke('dns_list_records');
+  return safeInvoke('dns_list_records');
 }
 
 export async function dns_add_record(record) {
-  return invoke('dns_add_record', { record });
+  return safeInvoke('dns_add_record', { record });
 }
 
 export async function dns_remove_record(id) {
-  return invoke('dns_remove_record', { id });
+  return safeInvoke('dns_remove_record', { id });
 }
 
 export async function http_get_status() {
-  return invoke('http_get_status');
+  return safeInvoke('http_get_status');
 }
 
 export async function http_stop_service() {
-  return invoke('http_stop_service');
+  return safeInvoke('http_stop_service');
 }
 
 export async function http_reload_config() {
-  return invoke('http_reload_config');
+  return safeInvoke('http_reload_config');
 }
 
 export async function http_list_routes() {
-  return invoke('http_list_routes');
+  return safeInvoke('http_list_routes');
 }
 
 export async function http_add_route(route) {
-  return invoke('http_add_route', { route });
+  return safeInvoke('http_add_route', { route });
 }
 
 export async function http_remove_route(id) {
-  return invoke('http_remove_route', { id });
+  return safeInvoke('http_remove_route', { id });
 }


### PR DESCRIPTION
## Summary
- add `isTauri` helper and refactor `safeInvoke`
- guard DNS and HTTP components from running outside Tauri

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2a19528488320a95480478b025f2a