### PR TITLE
Move WSL provisioning to on-demand workflow

### DIFF
--- a/home-lab/index.html
+++ b/home-lab/index.html
@@ -11,6 +11,7 @@
     <dns-records></dns-records>
     <http-status></http-status>
     <http-routes></http-routes>
+    <wsl-instance-manager></wsl-instance-manager>
     <toast-container></toast-container>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/home-lab/src-tauri/resources/install-services.nsh
+++ b/home-lab/src-tauri/resources/install-services.nsh
@@ -61,9 +61,6 @@ Var UNINS_DNS_OK
   StrCmp $LOG_HANDLE "" +2
   FileWrite $LOG_HANDLE "sc start HomeHttpService => rc=$0 out=$1$\r$\n"
     ; Exécution après installation
-  ; Forcer l’élévation (si pas déjà perMachine)
-  ; et lancer WSL sans distribution
-  nsExec::ExecToLog 'powershell -ExecutionPolicy Bypass -Command "wsl --install --no-distribution"'
   ; Close log file if opened
   StrCmp $LOG_HANDLE "" +2
   FileClose $LOG_HANDLE

--- a/home-lab/src-tauri/resources/install-services.wxs
+++ b/home-lab/src-tauri/resources/install-services.wxs
@@ -22,7 +22,6 @@
                   ExeCommand='[SystemFolder]sc.exe start HomeDnsService' Return="ignore" />
     <CustomAction Id="StartHomeHttp" Directory="INSTALLDIR" Execute="deferred" Impersonate="no"
                   ExeCommand='[SystemFolder]sc.exe start HomeHttpService' Return="ignore" />
-
     <!-- Uninstall: prefer binary uninstallers; rely on ServiceControl as safety net -->
     <CustomAction Id="UninstallHomeDns" Directory="INSTALLDIR" Execute="deferred" Impersonate="no"
                   ExeCommand='"[INSTALLDIR]bin\home-dns.exe" uninstall' Return="ignore" />

--- a/home-lab/src-tauri/resources/wsl/.gitignore
+++ b/home-lab/src-tauri/resources/wsl/.gitignore
@@ -1,0 +1,2 @@
+wsl-rootfs.tar
+wsl-rootfs.tar.gz

--- a/home-lab/src-tauri/resources/wsl/README.md
+++ b/home-lab/src-tauri/resources/wsl/README.md
@@ -1,0 +1,8 @@
+# WSL rootfs
+
+Ce dossier est empaqueté avec l'installateur Windows. Ajoutez-y l'archive `wsl-rootfs.tar`
+produite à partir de l'image `docker-image/` du dépôt (voir `docker build` + `docker export`).
+Le script `setup-wsl.ps1` s'appuie sur cette archive pour importer la distribution WSL
+"home-lab-k3s" puis injecte automatiquement la dernière version du binaire `k3s`.
+L'import n'est plus déclenché pendant l'installation : il est lancé à la demande depuis
+l'interface Home Lab (Tauri).

--- a/home-lab/src-tauri/resources/wsl/setup-wsl.ps1
+++ b/home-lab/src-tauri/resources/wsl/setup-wsl.ps1
@@ -1,0 +1,151 @@
+[CmdletBinding()]
+param(
+    [string]$DistroName = 'home-lab-k3s',
+    [string]$InstallDir = (Join-Path ${env:ProgramData} 'home-lab\\wsl'),
+    [string]$Rootfs     = (Join-Path $PSScriptRoot 'wsl-rootfs.tar'),
+    [switch]$ForceImport
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "[wsl-setup] $Message"
+}
+
+function Ensure-WslBinary {
+    if (-not (Get-Command 'wsl.exe' -ErrorAction SilentlyContinue)) {
+        throw 'wsl.exe introuvable. Activez WSL (wsl --install) puis relancez.'
+    }
+}
+
+function Get-RegisteredDistros {
+    $list = & wsl.exe -l -q 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Impossible de récupérer la liste des distributions WSL (code $LASTEXITCODE)."
+    }
+    $list | Where-Object { $_ -and ($_.Trim().Length -gt 0) } | ForEach-Object { $_.Trim() }
+}
+
+function Import-Distro {
+    param(
+        [string]$Name,
+        [string]$TargetDir,
+        [string]$TarPath
+    )
+
+    if (-not (Test-Path -LiteralPath $TarPath)) {
+        throw "Archive rootfs introuvable: $TarPath"
+    }
+
+    if (-not (Test-Path -LiteralPath $TargetDir)) {
+        Write-Info "Création du dossier cible $TargetDir"
+        New-Item -ItemType Directory -Path $TargetDir -Force | Out-Null
+    }
+
+    Write-Info "Import de la distribution $Name depuis $TarPath"
+    $args = @('--import', $Name, $TargetDir, $TarPath, '--version', '2')
+    $p = Start-Process -FilePath 'wsl.exe' -ArgumentList $args -Wait -PassThru -NoNewWindow
+    if ($p.ExitCode -ne 0) {
+        throw "Import WSL échoué (code $($p.ExitCode))"
+    }
+}
+
+function Get-LatestK3sReleaseTag {
+    $uri = 'https://api.github.com/repos/k3s-io/k3s/releases/latest'
+    $headers = @{ 'User-Agent' = 'home-lab-installer' }
+    try {
+        $resp = Invoke-RestMethod -Uri $uri -Headers $headers
+        if (-not $resp.tag_name) {
+            throw 'Réponse GitHub inattendue (tag_name absent).'
+        }
+        return [string]$resp.tag_name
+    } catch {
+        throw "Impossible de récupérer la version k3s: $($_.Exception.Message)"
+    }
+}
+
+function Download-K3sBinary {
+    param(
+        [string]$Tag
+    )
+
+    $downloadUri = "https://github.com/k3s-io/k3s/releases/download/$Tag/k3s"
+    $tempFile = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "k3s-$Tag")
+
+    Write-Info "Téléchargement de k3s ($Tag) ..."
+    try {
+        Invoke-WebRequest -Uri $downloadUri -OutFile $tempFile -UseBasicParsing | Out-Null
+    } catch {
+        throw "Téléchargement de k3s échoué: $($_.Exception.Message)"
+    }
+
+    return $tempFile
+}
+
+function Convert-ToWslPath {
+    param(
+        [string]$Distro,
+        [string]$WindowsPath
+    )
+
+    $full = Convert-Path -LiteralPath $WindowsPath
+    $linux = (& wsl.exe -d $Distro -- wslpath -a "$full" 2>$null)
+    if ($LASTEXITCODE -ne 0 -or -not $linux) {
+        throw "Conversion en chemin WSL échouée pour $full"
+    }
+    return $linux.Trim()
+}
+
+function Escape-ShellSingleQuotes {
+    param([string]$Value)
+    return $Value -replace "'", "'""'""'"
+}
+
+function Install-K3sBinary {
+    param(
+        [string]$Distro,
+        [string]$WindowsBinaryPath
+    )
+
+    $linuxPath = Convert-ToWslPath -Distro $Distro -WindowsPath $WindowsBinaryPath
+    $escaped = Escape-ShellSingleQuotes -Value $linuxPath
+    $cmd = "set -euo pipefail; install -m 0755 '$escaped' /usr/local/bin/k3s"
+    Write-Info "Installation de k3s dans la distribution $Distro"
+    $p = Start-Process -FilePath 'wsl.exe' -ArgumentList @('-d', $Distro, '--', 'sh', '-c', $cmd) -Wait -PassThru -NoNewWindow
+    if ($p.ExitCode -ne 0) {
+        throw "Installation de k3s échouée (code $($p.ExitCode))"
+    }
+}
+
+try {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Ensure-WslBinary
+
+    $distros = @(Get-RegisteredDistros)
+    $needsImport = $ForceImport.IsPresent -or -not ($distros -contains $DistroName)
+
+    if ($needsImport) {
+        Import-Distro -Name $DistroName -TargetDir $InstallDir -TarPath $Rootfs
+    } else {
+        Write-Info "Distribution $DistroName déjà présente, import ignoré."
+    }
+
+    $tag = Get-LatestK3sReleaseTag
+    $binary = Download-K3sBinary -Tag $tag
+
+    try {
+        Install-K3sBinary -Distro $DistroName -WindowsBinaryPath $binary
+    } finally {
+        if (Test-Path -LiteralPath $binary) {
+            Remove-Item -LiteralPath $binary -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Write-Info "Configuration WSL terminée."
+    exit 0
+} catch {
+    Write-Error "[wsl-setup] $($_.Exception.Message)"
+    exit 1
+}

--- a/home-lab/src-tauri/src/lib.rs
+++ b/home-lab/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod http;
 mod icons;
 mod menu;
 mod ui;
+mod wsl;
 
 static mut LOG_GUARD: Option<WorkerGuard> = None;
 
@@ -158,6 +159,7 @@ pub fn run() {
             http::http_list_routes,
             http::http_add_route,
             http::http_remove_route,
+            wsl::wsl_import_instance,
             ui::ui_log,
         ])
         .run(tauri::generate_context!())

--- a/home-lab/src-tauri/src/wsl.rs
+++ b/home-lab/src-tauri/src/wsl.rs
@@ -1,0 +1,135 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{anyhow, Context, Result};
+use serde::Serialize;
+use tauri::AppHandle;
+use tracing::{error, info, warn};
+
+#[derive(Serialize)]
+pub struct ProvisionResult {
+    ok: bool,
+    message: String,
+}
+
+fn resolve_install_dir(app: &AppHandle) -> Result<PathBuf> {
+    if let Some(pd) = std::env::var_os("PROGRAMDATA") {
+        return Ok(PathBuf::from(pd).join("home-lab").join("wsl"));
+    }
+
+    app.path()
+        .app_data_dir()
+        .map(|p| p.join("wsl"))
+        .context("Impossible de déterminer le dossier d'installation WSL")
+}
+
+#[tauri::command]
+pub async fn wsl_import_instance(
+    app: AppHandle,
+    force: Option<bool>,
+) -> Result<ProvisionResult, String> {
+    let force_import = force.unwrap_or(false);
+    let handle = app.clone();
+
+    info!(target: "wsl", force = force_import, "Demande d'import WSL reçue");
+
+    tauri::async_runtime::spawn_blocking(move || run_wsl_setup(&handle, force_import))
+        .await
+        .map_err(|e| {
+            error!(target: "wsl", "Erreur JoinHandle: {e}");
+            format!("Erreur interne: {e}")
+        })
+        .and_then(|result| {
+            result.map_err(|e| {
+                error!(target: "wsl", "Échec import WSL: {e}");
+                e.to_string()
+            })
+        })
+}
+
+fn run_wsl_setup(app: &AppHandle, force_import: bool) -> Result<ProvisionResult> {
+    let resource_dir = app
+        .path()
+        .resource_dir()
+        .context("Impossible de récupérer le dossier des ressources")?;
+    let wsl_dir = resource_dir.join("wsl");
+    let script_path = wsl_dir.join("setup-wsl.ps1");
+    if !script_path.exists() {
+        return Err(anyhow!(
+            "Script setup-wsl.ps1 introuvable dans {:?}",
+            script_path
+        ));
+    }
+
+    let rootfs_path = wsl_dir.join("wsl-rootfs.tar");
+    if !rootfs_path.exists() {
+        return Err(anyhow!("Archive rootfs introuvable dans {:?}", rootfs_path));
+    }
+
+    let install_dir = resolve_install_dir(app)?;
+
+    info!(
+        target: "wsl",
+        script = %script_path.display(),
+        rootfs = %rootfs_path.display(),
+        install = %install_dir.display(),
+        force = force_import,
+        "Lancement de setup-wsl.ps1"
+    );
+
+    let mut command = Command::new("powershell.exe");
+    command
+        .arg("-NoProfile")
+        .arg("-ExecutionPolicy")
+        .arg("Bypass")
+        .arg("-File")
+        .arg(&script_path)
+        .arg("-InstallDir")
+        .arg(&install_dir)
+        .arg("-Rootfs")
+        .arg(&rootfs_path);
+
+    if force_import {
+        command.arg("-ForceImport");
+    }
+
+    let output = command
+        .output()
+        .with_context(|| "Impossible d'exécuter setup-wsl.ps1".to_string())?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+
+    if output.status.success() {
+        if !stderr.is_empty() {
+            warn!(target: "wsl", "setup-wsl.ps1 stderr: {stderr}");
+        }
+        let mut message = if !stdout.is_empty() {
+            stdout
+        } else {
+            String::from("Instance WSL importée avec succès.")
+        };
+        if !stderr.is_empty() {
+            if !message.is_empty() {
+                message.push_str("\n");
+            }
+            message.push_str(&stderr);
+        }
+        info!(target: "wsl", "Import WSL terminé");
+        Ok(ProvisionResult { ok: true, message })
+    } else {
+        let code = output
+            .status
+            .code()
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "(code inconnu)".into());
+        let mut combined = stderr;
+        if combined.is_empty() {
+            combined = stdout;
+        }
+        if combined.is_empty() {
+            combined = format!("setup-wsl.ps1 a échoué (code {code})");
+        }
+        Err(anyhow!(combined))
+    }
+}

--- a/home-lab/src-tauri/tauri.conf.json
+++ b/home-lab/src-tauri/tauri.conf.json
@@ -40,6 +40,7 @@
       "resources/logs": "logs",
       "resources/conf": "conf",
       "resources/bin": "bin",
+      "resources/wsl": "wsl",
       "icons": "icons",
       "resources/version.txt": "version.txt"
     },

--- a/home-lab/src/components/wsl-instance.js
+++ b/home-lab/src/components/wsl-instance.js
@@ -1,0 +1,79 @@
+import { wsl_import_instance } from '../tauri.js';
+import { showError } from './toast.js';
+
+class WslInstanceManager extends HTMLElement {
+  constructor() {
+    super();
+    this._state = 'idle';
+    this._message = '';
+  }
+
+  connectedCallback() {
+    this.render();
+  }
+
+  setState(state, message = '') {
+    this._state = state;
+    this._message = message;
+    this.render();
+  }
+
+  render() {
+    const busy = this._state === 'running';
+    const message = this._message
+      ? `<p class="mt-3 text-sm whitespace-pre-wrap ${
+          this._state === 'error' ? 'text-red-600' : 'text-gray-700'
+        }">${this._message}</p>`
+      : '';
+
+    this.innerHTML = `
+      <div class="p-4 bg-gray-100 rounded">
+        <h2 class="font-bold mb-2">Instance WSL k3s</h2>
+        <p class="text-sm text-gray-600 mb-3">
+          Importez la distribution WSL fournie avec l'installateur et installez la dernière version de k3s.
+        </p>
+        <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            data-action="import"
+            class="px-3 py-2 rounded bg-blue-600 text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            ${busy ? 'disabled' : ''}
+          >
+            ${busy ? 'Import en cours…' : 'Ajouter une instance'}
+          </button>
+          <button
+            type="button"
+            data-action="force"
+            class="px-3 py-2 rounded border border-gray-400 text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            ${busy ? 'disabled' : ''}
+          >
+            ${busy ? 'Patientez…' : 'Réimporter (forcer)'}
+          </button>
+        </div>
+        ${message}
+      </div>
+    `;
+
+    this.querySelector('[data-action="import"]').addEventListener('click', () => this.run(false));
+    this.querySelector('[data-action="force"]').addEventListener('click', () => this.run(true));
+  }
+
+  async run(force) {
+    if (this._state === 'running') return;
+    this.setState('running', force ? 'Réimport forcé en cours…' : 'Import en cours…');
+    try {
+      const result = await wsl_import_instance({ force });
+      if (result?.ok) {
+        this.setState('success', result.message || 'Instance importée.');
+      } else {
+        throw new Error(result?.message || 'Import WSL échoué.');
+      }
+    } catch (err) {
+      const message = err?.message || String(err);
+      showError(message);
+      this.setState('error', message);
+    }
+  }
+}
+
+customElements.define('wsl-instance-manager', WslInstanceManager);

--- a/home-lab/src/main.js
+++ b/home-lab/src/main.js
@@ -5,3 +5,4 @@ import './components/dns-status.js';
 import './components/dns-records.js';
 import './components/http-status.js';
 import './components/http-routes.js';
+import './components/wsl-instance.js';

--- a/home-lab/src/tauri.js
+++ b/home-lab/src/tauri.js
@@ -129,6 +129,13 @@ async function mockInvoke(cmd, args = {}) {
       return { ok: removed, message: removed ? 'Route removed' : 'Not found' };
     }
 
+    case 'wsl_import_instance': {
+      return {
+        ok: true,
+        message: args?.force ? 'Réimport forcé (mock).' : 'Import WSL simulé (mock).',
+      };
+    }
+
     default:
       return { ok: false, message: `Unknown mock command: ${cmd}` };
   }
@@ -195,3 +202,7 @@ export async function http_list_routes() {
 export async function http_add_route(route) { return safeInvoke('http_add_route', { route }); }
 
 export async function http_remove_route(id) { return safeInvoke('http_remove_route', { id }); }
+
+export async function wsl_import_instance(options = {}) {
+  return safeInvoke('wsl_import_instance', options);
+}


### PR DESCRIPTION
## Summary
- remove the automatic WSL activation/import steps from the NSIS/MSI installers and elevated helper
- document that the bundled setup-wsl.ps1 script is now triggered on demand from the app
- add a Tauri command and front-end component so users can import or reimport the bundled WSL distro with the latest k3s when they choose

## Testing
- cargo check -p home-lab *(fails: missing system dependency glib-2.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68fb40809bf48320ad22d74a7b6b49a8