### PR TITLE
Fix tauri app path access

### DIFF
--- a/home-lab/src-tauri/src/wsl.rs
+++ b/home-lab/src-tauri/src/wsl.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 use anyhow::{anyhow, Context, Result};
 use serde::Serialize;
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 use tracing::{error, info, warn};
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary
- import the tauri Manager trait so the AppHandle::path helper is available

## Testing
- cargo check -p home-lab

------
https://chatgpt.com/codex/tasks/task_e_68fb4b4903408320904860f5786c5bcd