### PR TITLE
Allow naming and reimporting multiple WSL instances

### DIFF
--- a/home-lab/src-tauri/resources/wsl/setup-wsl.ps1
+++ b/home-lab/src-tauri/resources/wsl/setup-wsl.ps1
@@ -197,6 +197,7 @@ try {
     Ensure-WslBinary
 
     Write-Info "Parametres d'execution :"
+    Write-Info "  - DistroName = $DistroName"
     Write-Info "  - ForceImport = $($ForceImport.IsPresent)"
     Write-Info "  - InstallDir  = $InstallDir"
     Write-Info "  - Rootfs      = $Rootfs"


### PR DESCRIPTION
## Summary
- prompt for a WSL instance name when importing or forcing a reimport and prevent duplicate additions from the UI
- forward the chosen name through the frontend API/mock layer to the backend command invocation
- validate and log WSL instance names in the Rust backend, pass them to the setup script, and expose them in setup logging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69093cbcab3483209455c30ac6dcb2a7