### PR TITLE
Add Windows OIDC provider service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +810,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1002,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +1042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -1216,7 +1240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1303,6 +1327,20 @@ checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flexi_logger"
+version = "0.28.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca927478b3747ba47f98af6ba0ac0daea4f12d12f55e9104071b3dc00276310"
+dependencies = [
+ "chrono",
+ "glob",
+ "log",
+ "nu-ansi-term",
+ "regex",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1626,8 +1664,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1849,6 +1889,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
@@ -1883,7 +1929,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
- "flexi_logger",
+ "flexi_logger 0.31.7",
  "futures-util",
  "hyper-util",
  "log",
@@ -1912,7 +1958,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "chrono",
- "flexi_logger",
+ "flexi_logger 0.31.7",
  "futures-util",
  "http 1.3.1",
  "http-body-util",
@@ -2142,7 +2188,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2477,6 +2523,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,6 +2576,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libappindicator"
@@ -2820,10 +2884,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82c79c15c05d4bf82b6f5ef163104cc81a760d8e874d38ac50ab67c8877b647b"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2832,6 +2942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3140,6 +3251,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "oidc-service"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "flexi_logger 0.28.5",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "jsonwebtoken",
+ "log",
+ "once_cell",
+ "rand 0.8.5",
+ "rcgen",
+ "rsa",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "serde_with",
+ "sha2",
+ "tempfile",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "url",
+ "windows-service",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3238,6 +3381,25 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3457,6 +3619,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3650,7 +3833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -3670,7 +3853,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -3958,6 +4141,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4097,6 +4293,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4130,6 +4340,26 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rsa"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "rust_decimal"
@@ -4166,7 +4396,47 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -4264,6 +4534,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "seahash"
@@ -4534,6 +4814,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4544,6 +4834,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.17",
+ "time",
+]
 
 [[package]]
 name = "simplecss"
@@ -4656,6 +4958,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4706,6 +5024,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svgtypes"
@@ -5151,7 +5475,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5308,6 +5632,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -5335,6 +5660,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5353,8 +5688,12 @@ checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.15.5",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
@@ -5866,6 +6205,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6254,7 +6599,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6799,6 +7144,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6922,6 +7276,12 @@ dependencies = [
  "syn 2.0.106",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "home-dns",
   "home-http",
+  "oidc-service",
   "home-lab/src-tauri",
   "pipe-test",
   "service-tester"

--- a/oidc-service/Cargo.toml
+++ b/oidc-service/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "oidc-service"
+version = "0.1.0"
+edition = "2021"
+license = "GPL-3.0-only"
+authors = ["Homelab Maintainers <maintainers@example.com>"]
+description = "Minimal OIDC provider Windows service"
+
+[dependencies]
+anyhow = "1.0"
+base64 = "0.22"
+flexi_logger = "0.28"
+http = "1.1"
+http-body-util = "0.1"
+hyper = { version = "1.4", features = ["http1", "server"] }
+hyper-util = { version = "0.1", features = ["tokio", "server"] }
+jsonwebtoken = "9"
+log = "0.4"
+once_cell = "1.19"
+rand = "0.8"
+rcgen = { version = "0.13", features = ["pem"] }
+rsa = { version = "0.9", features = ["pem"] }
+rustls = "0.21"
+rustls-pemfile = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_with = { version = "3.8", features = ["macros"] }
+serde_urlencoded = "0.7"
+sha2 = "0.10"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "time", "net"] }
+tokio-rustls = "0.24"
+tokio-util = { version = "0.7", features = ["full"] }
+url = "2.5"
+windows-service = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.10"

--- a/oidc-service/src/main.rs
+++ b/oidc-service/src/main.rs
@@ -1,0 +1,1070 @@
+#![cfg_attr(not(windows), allow(dead_code))]
+#![cfg_attr(
+    all(not(debug_assertions), target_os = "windows"),
+    windows_subsystem = "windows"
+)]
+
+use anyhow::{anyhow, Context, Result};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use flexi_logger::{Age, Cleanup, Criterion, Duplicate, FileSpec, Logger, Naming};
+use http::{Method, StatusCode};
+use http_body_util::{BodyExt, Full};
+use hyper::body::{Bytes, Incoming};
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::TokioIo;
+use jsonwebtoken::{EncodingKey, Header};
+use log::{error, info};
+use rand::RngCore;
+use rcgen::{CertificateParams, DnType, IsCa, KeyPair, SanType};
+use rsa::pkcs1::DecodeRsaPrivateKey;
+use rsa::pkcs8::DecodePrivateKey;
+use rsa::traits::PublicKeyParts;
+use rsa::RsaPrivateKey;
+use rustls::{Certificate as RustlsCertificate, PrivateKey as RustlsPrivateKey, ServerConfig};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use serde_with::skip_serializing_none;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::convert::TryInto;
+use std::fs::{self, File};
+use std::io::{BufReader, Write};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::net::TcpListener;
+use tokio::runtime::Runtime;
+use tokio_util::sync::CancellationToken;
+use url::Url;
+
+#[cfg(windows)]
+use log::warn;
+#[cfg(windows)]
+use once_cell::sync::Lazy;
+#[cfg(windows)]
+use std::ffi::OsString;
+use tokio_rustls::TlsAcceptor;
+
+#[cfg(windows)]
+use windows_service::service::{
+    ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus, ServiceType,
+};
+#[cfg(windows)]
+use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
+#[cfg(windows)]
+use windows_service::{
+    define_windows_service,
+    service::{ServiceAccess, ServiceErrorControl, ServiceStartType},
+    service_manager::{ServiceInfo, ServiceManager, ServiceManagerAccess},
+};
+
+const SERVICE_NAME: &str = "OidcService";
+const SERVICE_DISPLAY_NAME: &str = "OIDC Service";
+const SERVICE_DESCRIPTION: &str = "Minimal HTTPS OIDC provider with HTTP mirror";
+
+fn program_data_dir() -> PathBuf {
+    PathBuf::from(r"C:\\ProgramData\\oidc-service\\oidc")
+}
+
+fn logs_dir() -> PathBuf {
+    program_data_dir().join("logs")
+}
+
+fn config_path() -> PathBuf {
+    program_data_dir().join("oidc-config.json")
+}
+
+fn private_key_path() -> PathBuf {
+    program_data_dir().join("oidc-private-key.pem")
+}
+
+fn certificate_path() -> PathBuf {
+    program_data_dir().join("oidc-cert.pem")
+}
+
+fn jwks_path() -> PathBuf {
+    program_data_dir().join("oidc-jwks.json")
+}
+
+fn default_http_port() -> u16 {
+    8000
+}
+
+fn default_https_port() -> u16 {
+    8443
+}
+
+fn default_issuer() -> String {
+    "https://127.0.0.1:8443".to_string()
+}
+
+fn default_token_ttl() -> u64 {
+    3600
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PasswordUser {
+    username: String,
+    password: String,
+    #[serde(default)]
+    subject: Option<String>,
+    #[serde(default)]
+    scopes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ClientConfig {
+    client_id: String,
+    client_secret: String,
+    #[serde(default)]
+    allowed_scopes: Vec<String>,
+    #[serde(default)]
+    subject: Option<String>,
+    #[serde(default)]
+    audiences: Vec<String>,
+    #[serde(default)]
+    password_users: Vec<PasswordUser>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ServiceConfig {
+    #[serde(default = "default_http_port")]
+    http_port: u16,
+    #[serde(default = "default_https_port")]
+    https_port: u16,
+    #[serde(default = "default_issuer")]
+    issuer: String,
+    #[serde(default)]
+    audiences: Vec<String>,
+    #[serde(default)]
+    clients: Vec<ClientConfig>,
+    #[serde(default = "default_token_ttl")]
+    token_ttl_secs: u64,
+    #[serde(default)]
+    log_level: Option<String>,
+}
+
+impl Default for ServiceConfig {
+    fn default() -> Self {
+        let mut secret = [0u8; 24];
+        rand::thread_rng().fill_bytes(&mut secret);
+        let default_secret = URL_SAFE_NO_PAD.encode(secret);
+        ServiceConfig {
+            http_port: default_http_port(),
+            https_port: default_https_port(),
+            issuer: default_issuer(),
+            audiences: vec!["https://example-app".to_string()],
+            clients: vec![ClientConfig {
+                client_id: "demo-client".to_string(),
+                client_secret: default_secret,
+                allowed_scopes: vec!["demo.read".to_string()],
+                subject: Some("demo-client".to_string()),
+                audiences: vec![],
+                password_users: vec![PasswordUser {
+                    username: "demo-user".to_string(),
+                    password: "change-me".to_string(),
+                    subject: Some("demo-user".to_string()),
+                    scopes: vec!["demo.read".to_string()],
+                }],
+            }],
+            token_ttl_secs: default_token_ttl(),
+            log_level: Some("info".to_string()),
+        }
+    }
+}
+
+fn level_from_cfg(cfg: &ServiceConfig) -> log::LevelFilter {
+    match cfg.log_level.as_deref().unwrap_or("info") {
+        "trace" => log::LevelFilter::Trace,
+        "debug" => log::LevelFilter::Debug,
+        "warn" => log::LevelFilter::Warn,
+        "error" => log::LevelFilter::Error,
+        "off" => log::LevelFilter::Off,
+        _ => log::LevelFilter::Info,
+    }
+}
+
+fn init_logger(level: log::LevelFilter) -> Result<()> {
+    let dir = logs_dir();
+    fs::create_dir_all(&dir)
+        .with_context(|| format!("creating log directory {}", dir.display()))?;
+    Logger::try_with_env_or_str(level.as_str())?
+        .log_to_file(
+            FileSpec::default()
+                .directory(dir)
+                .basename("oidc-service")
+                .suffix("log"),
+        )
+        .duplicate_to_stderr(Duplicate::Error)
+        .rotate(
+            Criterion::Age(Age::Day),
+            Naming::Timestamps,
+            Cleanup::KeepLogFiles(7),
+        )
+        .start()?;
+    Ok(())
+}
+
+fn ensure_program_data() -> Result<()> {
+    let dir = program_data_dir();
+    fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+    Ok(())
+}
+
+fn load_config_or_init() -> Result<ServiceConfig> {
+    ensure_program_data()?;
+    let cfg_path = config_path();
+    if cfg_path.exists() {
+        let data =
+            fs::read(&cfg_path).with_context(|| format!("reading {}", cfg_path.display()))?;
+        let cfg: ServiceConfig = serde_json::from_slice(&data).with_context(|| "parsing config")?;
+        Ok(cfg)
+    } else {
+        let cfg = ServiceConfig::default();
+        let json = serde_json::to_vec_pretty(&cfg)?;
+        fs::write(&cfg_path, json).with_context(|| format!("writing {}", cfg_path.display()))?;
+        Ok(cfg)
+    }
+}
+
+fn write_atomic(path: &Path, data: &[u8]) -> Result<()> {
+    let tmp_path = path.with_extension("tmp");
+    {
+        let mut f = File::create(&tmp_path)
+            .with_context(|| format!("create temp {}", tmp_path.display()))?;
+        f.write_all(data)?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp_path, path)
+        .with_context(|| format!("rename {} -> {}", tmp_path.display(), path.display()))?;
+    Ok(())
+}
+
+struct KeyMaterial {
+    encoding: EncodingKey,
+    kid: String,
+    jwks_json: String,
+    tls_config: Arc<ServerConfig>,
+}
+
+fn ensure_certificate(cfg: &ServiceConfig) -> Result<()> {
+    if private_key_path().exists() && certificate_path().exists() {
+        return Ok(());
+    }
+    let issuer = Url::parse(&cfg.issuer).context("invalid issuer url")?;
+    let host = issuer
+        .host_str()
+        .ok_or_else(|| anyhow!("issuer host missing"))?
+        .to_string();
+    let mut params = CertificateParams::new(vec![host.clone()])?;
+    params.is_ca = IsCa::NoCa;
+    params
+        .distinguished_name
+        .push(DnType::CommonName, host.clone());
+    params
+        .subject_alt_names
+        .push(SanType::DnsName("localhost".to_string().try_into()?));
+    params
+        .subject_alt_names
+        .push(SanType::DnsName(host.clone().try_into()?));
+    params
+        .subject_alt_names
+        .push(SanType::IpAddress(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
+    if let Ok(ip) = host.parse::<Ipv4Addr>() {
+        params
+            .subject_alt_names
+            .push(SanType::IpAddress(IpAddr::V4(ip)));
+    }
+    let key_pair = KeyPair::generate_for(&rcgen::PKCS_RSA_SHA256)?;
+    let cert = params.self_signed(&key_pair)?;
+    let key_pem = key_pair.serialize_pem();
+    let cert_pem = cert.pem();
+    write_atomic(&private_key_path(), key_pem.as_bytes())?;
+    write_atomic(&certificate_path(), cert_pem.as_bytes())?;
+    Ok(())
+}
+
+fn load_key_material(cfg: &ServiceConfig) -> Result<KeyMaterial> {
+    ensure_certificate(cfg)?;
+    let key_pem = fs::read_to_string(private_key_path()).context("read private key")?;
+    let cert_pem = fs::read_to_string(certificate_path()).context("read certificate")?;
+
+    let encoding = EncodingKey::from_rsa_pem(key_pem.as_bytes()).context("encoding key")?;
+
+    let rsa_key = RsaPrivateKey::from_pkcs1_pem(&key_pem)
+        .or_else(|_| RsaPrivateKey::from_pkcs8_pem(&key_pem))
+        .context("parsing rsa key")?;
+    let public_key = rsa_key.to_public_key();
+    let n_bytes = public_key.n().to_bytes_be();
+    let e_bytes = public_key.e().to_bytes_be();
+    let mut hasher = Sha256::new();
+    hasher.update(&n_bytes);
+    hasher.update(&e_bytes);
+    let kid = URL_SAFE_NO_PAD.encode(hasher.finalize());
+
+    let jwk = json!({
+        "kty": "RSA",
+        "use": "sig",
+        "alg": "RS256",
+        "kid": kid,
+        "n": URL_SAFE_NO_PAD.encode(&n_bytes),
+        "e": URL_SAFE_NO_PAD.encode(&e_bytes),
+    });
+    let jwks = json!({ "keys": [jwk] });
+    let jwks_json = serde_json::to_string_pretty(&jwks)?;
+    write_atomic(&jwks_path(), jwks_json.as_bytes())?;
+
+    let mut cert_reader = BufReader::new(cert_pem.as_bytes());
+    let certs = rustls_pemfile::certs(&mut cert_reader).context("read rustls certs")?;
+    let mut key_reader = BufReader::new(key_pem.as_bytes());
+    let mut keys = rustls_pemfile::pkcs8_private_keys(&mut key_reader).context("read pkcs8 key")?;
+    if keys.is_empty() {
+        key_reader = BufReader::new(key_pem.as_bytes());
+        keys = rustls_pemfile::rsa_private_keys(&mut key_reader).context("read rsa key")?;
+    }
+    if keys.is_empty() {
+        return Err(anyhow!("no private key material"));
+    }
+    let tls_config = ServerConfig::builder()
+        .with_safe_defaults()
+        .with_no_client_auth()
+        .with_single_cert(
+            certs.into_iter().map(RustlsCertificate).collect(),
+            RustlsPrivateKey(keys[0].clone()),
+        )?;
+
+    Ok(KeyMaterial {
+        encoding,
+        kid,
+        jwks_json,
+        tls_config: Arc::new(tls_config),
+    })
+}
+
+#[skip_serializing_none]
+#[derive(Serialize)]
+struct WellKnownResponse {
+    issuer: String,
+    authorization_endpoint: Option<String>,
+    token_endpoint: String,
+    jwks_uri: String,
+    response_types_supported: Vec<String>,
+    grant_types_supported: Vec<String>,
+    token_endpoint_auth_methods_supported: Vec<String>,
+    scopes_supported: Vec<String>,
+    subject_types_supported: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct TokenResponse {
+    access_token: String,
+    token_type: &'static str,
+    expires_in: u64,
+    scope: String,
+}
+
+#[derive(Deserialize)]
+struct TokenRequest {
+    grant_type: String,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    audience: Option<String>,
+    #[serde(default)]
+    resource: Option<String>,
+    #[serde(default)]
+    client_id: Option<String>,
+    #[serde(default)]
+    client_secret: Option<String>,
+    #[serde(default)]
+    username: Option<String>,
+    #[serde(default)]
+    password: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct TokenClaims {
+    iss: String,
+    sub: String,
+    aud: Vec<String>,
+    iat: u64,
+    exp: u64,
+    scope: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_id: Option<String>,
+}
+
+struct AppState {
+    cfg: ServiceConfig,
+    clients: HashMap<String, ClientConfig>,
+    key: EncodingKey,
+    kid: String,
+    jwks_json: String,
+}
+
+impl AppState {
+    fn audience_for(
+        &self,
+        client: &ClientConfig,
+        requested: Option<String>,
+        resource: Option<String>,
+    ) -> Result<Vec<String>> {
+        if let Some(req) = requested.or(resource) {
+            let allowed = if client.audiences.is_empty() {
+                &self.cfg.audiences
+            } else {
+                &client.audiences
+            };
+            if allowed.is_empty() || allowed.iter().any(|a| a == &req) {
+                return Ok(vec![req]);
+            } else {
+                anyhow::bail!("audience not allowed");
+            }
+        }
+        if !client.audiences.is_empty() {
+            return Ok(client.audiences.clone());
+        }
+        if !self.cfg.audiences.is_empty() {
+            return Ok(vec![self.cfg.audiences[0].clone()]);
+        }
+        anyhow::bail!("no audience configured");
+    }
+
+    fn scopes_for(&self, client: &ClientConfig, request_scope: Option<String>) -> Result<String> {
+        if let Some(scope) = request_scope {
+            if client.allowed_scopes.is_empty() {
+                return Ok(scope);
+            }
+            let requested: Vec<&str> = scope.split_whitespace().collect();
+            let mut invalid = vec![];
+            for s in &requested {
+                if !client.allowed_scopes.iter().any(|allowed| allowed == s) {
+                    invalid.push((*s).to_string());
+                }
+            }
+            if !invalid.is_empty() {
+                anyhow::bail!(format!("invalid scope(s): {}", invalid.join(", ")));
+            }
+            return Ok(scope);
+        }
+        if client.allowed_scopes.is_empty() {
+            Ok(String::new())
+        } else {
+            Ok(client.allowed_scopes.join(" "))
+        }
+    }
+}
+
+fn collect_supported_scopes(clients: &HashMap<String, ClientConfig>) -> Vec<String> {
+    let mut scopes = Vec::new();
+    for client in clients.values() {
+        for scope in &client.allowed_scopes {
+            if !scopes.contains(scope) {
+                scopes.push(scope.clone());
+            }
+        }
+    }
+    scopes
+}
+
+async fn handle_request(
+    req: Request<Incoming>,
+    state: Arc<AppState>,
+) -> Result<Response<Full<Bytes>>> {
+    let path = req.uri().path().to_string();
+    match (req.method(), path.as_str()) {
+        (&Method::GET, "/.well-known/openid-configuration") => {
+            let response = WellKnownResponse {
+                issuer: state.cfg.issuer.clone(),
+                authorization_endpoint: None,
+                token_endpoint: format!("{}/token", state.cfg.issuer),
+                jwks_uri: format!("{}/jwks.json", state.cfg.issuer),
+                response_types_supported: vec!["token".into()],
+                grant_types_supported: vec!["client_credentials".into(), "password".into()],
+                token_endpoint_auth_methods_supported: vec![
+                    "client_secret_basic".into(),
+                    "client_secret_post".into(),
+                ],
+                scopes_supported: collect_supported_scopes(&state.clients),
+                subject_types_supported: vec!["public".into()],
+            };
+            let body = serde_json::to_vec(&response)?;
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .body(Full::from(body))?)
+        }
+        (&Method::GET, "/jwks.json") => Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .body(Full::from(state.jwks_json.clone()))?),
+        (&Method::POST, "/token") => handle_token(req, state).await,
+        _ => Ok(Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Full::from("not found"))?),
+    }
+}
+
+fn parse_basic_auth(header: &str) -> Option<(String, String)> {
+    let encoded = header.strip_prefix("Basic ")?;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .ok()?;
+    let decoded_str = String::from_utf8(decoded).ok()?;
+    let (id, secret) = decoded_str.split_once(':')?;
+    Some((id.to_string(), secret.to_string()))
+}
+
+async fn handle_token(
+    req: Request<Incoming>,
+    state: Arc<AppState>,
+) -> Result<Response<Full<Bytes>>> {
+    let headers = req.headers().clone();
+    let collected = req.into_body().collect().await?;
+    let body_bytes = collected.to_bytes();
+    let mut params: HashMap<String, String> =
+        serde_urlencoded::from_bytes(&body_bytes).unwrap_or_default();
+    if let Some(auth) = headers.get(http::header::AUTHORIZATION) {
+        if let Ok(auth_str) = auth.to_str() {
+            if let Some((client_id, client_secret)) = parse_basic_auth(auth_str) {
+                params.entry("client_id".into()).or_insert(client_id);
+                params
+                    .entry("client_secret".into())
+                    .or_insert(client_secret);
+            }
+        }
+    }
+    let request = TokenRequest::from(params);
+    process_token_request(request, state)
+}
+
+impl From<HashMap<String, String>> for TokenRequest {
+    fn from(mut map: HashMap<String, String>) -> Self {
+        TokenRequest {
+            grant_type: map.remove("grant_type").unwrap_or_default(),
+            scope: map.remove("scope"),
+            audience: map.remove("audience"),
+            resource: map.remove("resource"),
+            client_id: map.remove("client_id"),
+            client_secret: map.remove("client_secret"),
+            username: map.remove("username"),
+            password: map.remove("password"),
+        }
+    }
+}
+
+fn json_error(status: StatusCode, code: &str, desc: &str) -> Result<Response<Full<Bytes>>> {
+    Ok(Response::builder()
+        .status(status)
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(Full::from(
+            json!({"error": code, "error_description": desc}).to_string(),
+        ))?)
+}
+
+fn process_token_request(req: TokenRequest, state: Arc<AppState>) -> Result<Response<Full<Bytes>>> {
+    if req.grant_type.is_empty() {
+        return json_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "grant_type required",
+        );
+    }
+    let client_id = match req.client_id.clone() {
+        Some(id) => id,
+        None => {
+            return json_error(
+                StatusCode::UNAUTHORIZED,
+                "invalid_client",
+                "client authentication required",
+            )
+        }
+    };
+    let client = match state.clients.get(&client_id).cloned() {
+        Some(c) => c,
+        None => return json_error(StatusCode::UNAUTHORIZED, "invalid_client", "unknown client"),
+    };
+    if client.client_secret != req.client_secret.as_deref().unwrap_or_default() {
+        return json_error(
+            StatusCode::UNAUTHORIZED,
+            "invalid_client",
+            "invalid client secret",
+        );
+    }
+    match req.grant_type.as_str() {
+        "client_credentials" => issue_client_credentials_token(req, state, &client),
+        "password" => issue_password_token(req, state, &client),
+        _ => json_error(
+            StatusCode::BAD_REQUEST,
+            "unsupported_grant_type",
+            "grant type not supported",
+        ),
+    }
+}
+
+fn issue_client_credentials_token(
+    req: TokenRequest,
+    state: Arc<AppState>,
+    client: &ClientConfig,
+) -> Result<Response<Full<Bytes>>> {
+    let scopes = state
+        .scopes_for(client, req.scope.clone())
+        .map_err(|e| anyhow!(e))?;
+    let aud = state
+        .audience_for(client, req.audience.clone(), req.resource.clone())
+        .map_err(|e| anyhow!(e))?;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| Duration::from_secs(0));
+    let exp = now + Duration::from_secs(state.cfg.token_ttl_secs);
+    let claims = TokenClaims {
+        iss: state.cfg.issuer.clone(),
+        sub: client
+            .subject
+            .clone()
+            .unwrap_or_else(|| client.client_id.clone()),
+        aud,
+        iat: now.as_secs(),
+        exp: exp.as_secs(),
+        scope: scopes.clone(),
+        client_id: Some(client.client_id.clone()),
+    };
+    let mut header = Header::new(jsonwebtoken::Algorithm::RS256);
+    header.kid = Some(state.kid.clone());
+    let token = jsonwebtoken::encode(&header, &claims, &state.key).map_err(|e| anyhow!(e))?;
+    let body = serde_json::to_vec(&TokenResponse {
+        access_token: token,
+        token_type: "Bearer",
+        expires_in: state.cfg.token_ttl_secs,
+        scope: scopes,
+    })?;
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(Full::from(body))?)
+}
+
+fn issue_password_token(
+    req: TokenRequest,
+    state: Arc<AppState>,
+    client: &ClientConfig,
+) -> Result<Response<Full<Bytes>>> {
+    let username = match req.username.clone() {
+        Some(u) => u,
+        None => {
+            return json_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "username required",
+            )
+        }
+    };
+    let password = match req.password.clone() {
+        Some(p) => p,
+        None => {
+            return json_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "password required",
+            )
+        }
+    };
+    let user = match client
+        .password_users
+        .iter()
+        .find(|u| u.username == username && u.password == password)
+    {
+        Some(u) => u,
+        None => {
+            return json_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_grant",
+                "invalid user credentials",
+            )
+        }
+    };
+    let scopes = if !user.scopes.is_empty() {
+        user.scopes.join(" ")
+    } else {
+        state
+            .scopes_for(client, req.scope.clone())
+            .map_err(|e| anyhow!(e))?
+    };
+    let aud = state
+        .audience_for(client, req.audience.clone(), req.resource.clone())
+        .map_err(|e| anyhow!(e))?;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| Duration::from_secs(0));
+    let exp = now + Duration::from_secs(state.cfg.token_ttl_secs);
+    let claims = TokenClaims {
+        iss: state.cfg.issuer.clone(),
+        sub: user.subject.clone().unwrap_or_else(|| username.clone()),
+        aud,
+        iat: now.as_secs(),
+        exp: exp.as_secs(),
+        scope: scopes.clone(),
+        client_id: Some(client.client_id.clone()),
+    };
+    let mut header = Header::new(jsonwebtoken::Algorithm::RS256);
+    header.kid = Some(state.kid.clone());
+    let token = jsonwebtoken::encode(&header, &claims, &state.key).map_err(|e| anyhow!(e))?;
+    let body = serde_json::to_vec(&TokenResponse {
+        access_token: token,
+        token_type: "Bearer",
+        expires_in: state.cfg.token_ttl_secs,
+        scope: scopes,
+    })?;
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(Full::from(body))?)
+}
+
+async fn serve_http(
+    addr: SocketAddr,
+    state: Arc<AppState>,
+    cancel: CancellationToken,
+) -> Result<()> {
+    let listener = TcpListener::bind(addr).await?;
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("HTTP server on {} stopping", addr);
+                break;
+            }
+            accept = listener.accept() => {
+                let (stream, _) = accept?;
+                let state = state.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(TokioIo::new(stream), service_fn(|req| {
+                            let state = state.clone();
+                            async move {
+                                match handle_request(req, state).await {
+                                    Ok(resp) => Ok::<_, anyhow::Error>(resp),
+                                    Err(e) => {
+                                        error!("request error: {e:?}");
+                                        let body = Full::from(json!({"error": "server_error"}).to_string());
+                                        Ok(Response::builder()
+                                            .status(StatusCode::INTERNAL_SERVER_ERROR)
+                                            .header(http::header::CONTENT_TYPE, "application/json")
+                                            .body(body)
+                                            .unwrap())
+                                    }
+                                }
+                            }
+                        }))
+                        .await {
+                        error!("http connection error: {e:?}");
+                    }
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn serve_https(
+    addr: SocketAddr,
+    state: Arc<AppState>,
+    cancel: CancellationToken,
+    tls: Arc<ServerConfig>,
+) -> Result<()> {
+    let listener = TcpListener::bind(addr).await?;
+    let acceptor = TlsAcceptor::from(tls);
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("HTTPS server on {} stopping", addr);
+                break;
+            }
+            accept = listener.accept() => {
+                let (stream, _) = accept?;
+                let state = state.clone();
+                let acceptor = acceptor.clone();
+                tokio::spawn(async move {
+                    match acceptor.accept(stream).await {
+                        Ok(tls_stream) => {
+                            if let Err(e) = hyper::server::conn::http1::Builder::new()
+                                .serve_connection(TokioIo::new(tls_stream), service_fn(|req| {
+                                    let state = state.clone();
+                                    async move {
+                                        match handle_request(req, state).await {
+                                            Ok(resp) => Ok::<_, anyhow::Error>(resp),
+                                            Err(e) => {
+                                                error!("request error: {e:?}");
+                                                let body = Full::from(json!({"error": "server_error"}).to_string());
+                                                Ok(Response::builder()
+                                                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                                                    .header(http::header::CONTENT_TYPE, "application/json")
+                                                    .body(body)
+                                                    .unwrap())
+                                            }
+                                        }
+                                    }
+                                }))
+                                .await {
+                                error!("https connection error: {e:?}");
+                            }
+                        }
+                        Err(e) => {
+                            error!("tls accept error: {e:?}");
+                        }
+                    }
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run_servers(cfg: ServiceConfig, material: KeyMaterial, cancel: CancellationToken) -> Result<()> {
+    let rt = Runtime::new()?;
+    let clients = cfg
+        .clients
+        .iter()
+        .map(|c| (c.client_id.clone(), c.clone()))
+        .collect();
+    let state = Arc::new(AppState {
+        cfg: cfg.clone(),
+        clients,
+        key: material.encoding,
+        kid: material.kid,
+        jwks_json: material.jwks_json,
+    });
+    let http_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), cfg.http_port);
+    let https_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), cfg.https_port);
+    let tls = material.tls_config.clone();
+    rt.block_on(async {
+        let cancel_http = cancel.clone();
+        let cancel_https = cancel.clone();
+        let http = tokio::spawn(serve_http(http_addr, state.clone(), cancel_http));
+        let https = tokio::spawn(serve_https(https_addr, state.clone(), cancel_https, tls));
+        tokio::select! {
+            res = http => {
+                if let Err(e) = res {
+                    error!("http task join error: {e:?}");
+                }
+            }
+            res = https => {
+                if let Err(e) = res {
+                    error!("https task join error: {e:?}");
+                }
+            }
+            _ = cancel.cancelled() => {}
+        }
+    });
+    Ok(())
+}
+
+#[cfg(windows)]
+fn install_service() -> Result<()> {
+    ensure_program_data()?;
+    let cfg = load_config_or_init()?;
+    let _material = load_key_material(&cfg)?;
+    import_certificate_to_trust_store(&certificate_path())?;
+    ensure_firewall_rule(cfg.https_port)?;
+    let exe_path = std::env::current_exe()?;
+    let manager = ServiceManager::local_computer(
+        None::<&str>,
+        ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE,
+    )?;
+    if let Ok(_) = manager.open_service(SERVICE_NAME, ServiceAccess::QUERY_STATUS) {
+        info!("service already installed");
+        return Ok(());
+    }
+    let service_info = ServiceInfo {
+        name: SERVICE_NAME.into(),
+        display_name: SERVICE_DISPLAY_NAME.into(),
+        service_type: ServiceType::OWN_PROCESS,
+        start_type: ServiceStartType::AutoStart,
+        error_control: ServiceErrorControl::Normal,
+        executable_path: exe_path.clone(),
+        launch_arguments: vec!["run".into()],
+        dependencies: vec![],
+        account_name: None,
+        account_password: None,
+    };
+    let service = manager.create_service(
+        &service_info,
+        ServiceAccess::CHANGE_CONFIG | ServiceAccess::START,
+    )?;
+    service.set_description(SERVICE_DESCRIPTION)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn uninstall_service() -> Result<()> {
+    let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)?;
+    let service = manager.open_service(
+        SERVICE_NAME,
+        ServiceAccess::STOP | ServiceAccess::QUERY_STATUS | ServiceAccess::DELETE,
+    )?;
+    let _ = service.stop();
+    for _ in 0..20 {
+        if let Ok(status) = service.query_status() {
+            if status.current_state == ServiceState::Stopped {
+                break;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+    service.delete()?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn import_certificate_to_trust_store(path: &Path) -> Result<()> {
+    let path_str = path.display().to_string();
+    let status = std::process::Command::new("powershell.exe")
+        .args([
+            "-NoProfile",
+            "-Command",
+            &format!(
+                "try {{ Import-Certificate -FilePath '{}' -CertStoreLocation Cert:\\LocalMachine\\Root -ErrorAction Stop }} catch {{ Import-Certificate -FilePath '{}' -CertStoreLocation Cert:\\CurrentUser\\Root }}",
+                path_str, path_str
+            ),
+        ])
+        .status()?;
+    if !status.success() {
+        warn!("certificate import failed with status {:?}", status);
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn ensure_firewall_rule(port: u16) -> Result<()> {
+    let rule_name = format!("OIDC Service {port}");
+    let check = std::process::Command::new("netsh")
+        .args([
+            "advfirewall",
+            "firewall",
+            "show",
+            "rule",
+            &format!("name={rule_name}"),
+        ])
+        .status();
+    if let Ok(status) = check {
+        if status.success() {
+            return Ok(());
+        }
+    }
+    let status = std::process::Command::new("netsh")
+        .args([
+            "advfirewall",
+            "firewall",
+            "add",
+            "rule",
+            &format!("name={rule_name}"),
+            "dir=in",
+            "action=allow",
+            "protocol=TCP",
+            &format!("localport={port}"),
+        ])
+        .status()?;
+    if !status.success() {
+        warn!("failed to create firewall rule status {:?}", status);
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+static STOP_TOKEN: Lazy<CancellationToken> = Lazy::new(CancellationToken::new);
+
+#[cfg(windows)]
+define_windows_service!(ffi_service_main, service_main);
+
+#[cfg(windows)]
+fn service_main(_args: Vec<OsString>) {
+    if let Err(e) = run_service() {
+        error!("service error: {e:?}");
+    }
+}
+
+#[cfg(windows)]
+fn run_service() -> Result<()> {
+    let cancel = STOP_TOKEN.clone();
+    let event_handler = move |control_event| -> ServiceControlHandlerResult {
+        match control_event {
+            ServiceControl::Stop | ServiceControl::Shutdown => {
+                cancel.cancel();
+                ServiceControlHandlerResult::NoError
+            }
+            _ => ServiceControlHandlerResult::NotImplemented,
+        }
+    };
+    let status_handle = service_control_handler::register(SERVICE_NAME, event_handler)?;
+    let set_status = |state: ServiceState| {
+        let _ = status_handle.set_service_status(ServiceStatus {
+            service_type: ServiceType::OWN_PROCESS,
+            current_state: state,
+            controls_accepted: ServiceControlAccept::STOP | ServiceControlAccept::SHUTDOWN,
+            exit_code: ServiceExitCode::Win32(0),
+            checkpoint: 0,
+            wait_hint: Duration::from_secs(10),
+            process_id: None,
+        });
+    };
+    set_status(ServiceState::StartPending);
+    let cfg = load_config_or_init()?;
+    let level = level_from_cfg(&cfg);
+    init_logger(level)?;
+    info!("OIDC service starting");
+    let material = load_key_material(&cfg)?;
+    set_status(ServiceState::Running);
+    run_servers(cfg, material, cancel.clone())?;
+    set_status(ServiceState::Stopped);
+    Ok(())
+}
+
+#[cfg(windows)]
+fn usage() {
+    eprintln!("Usage: oidc-service [run|install|uninstall|console]");
+}
+
+#[cfg(windows)]
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() <= 1 {
+        usage();
+        return Ok(());
+    }
+    match args[1].as_str() {
+        "run" => {
+            if let Err(e) =
+                windows_service::service_dispatcher::start(SERVICE_NAME, ffi_service_main)
+            {
+                error!("service dispatcher error: {e:?}");
+            }
+        }
+        "install" => {
+            install_service()?;
+            println!(
+                "Service installed. Update {} then start the service.",
+                config_path().display()
+            );
+        }
+        "uninstall" => {
+            uninstall_service()?;
+            println!("Service uninstalled.");
+        }
+        "console" => {
+            let cfg = load_config_or_init()?;
+            init_logger(level_from_cfg(&cfg))?;
+            let cancel = CancellationToken::new();
+            let material = load_key_material(&cfg)?;
+            run_servers(cfg, material, cancel)?;
+        }
+        _ => usage(),
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn main() -> Result<()> {
+    anyhow::bail!("Windows only");
+}


### PR DESCRIPTION
## Summary
- add a new `oidc-service` crate that exposes an HTTPS/HTTP OIDC provider with RS256-signed tokens and JWKS publishing
- generate and persist RSA key material, self-signed certificates, and service configuration under ProgramData while wiring Windows service lifecycle hooks
- implement client credentials and password token flows backed by configurable clients and scopes

## Testing
- cargo check -p oidc-service

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f75104d708320aa10022ac54aaace)