### PR TITLE
Rename OIDC service to home-oidc and bundle installer assets

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -46,10 +46,12 @@ jobs:
         run: |
           cargo build -p home-dns   --release --target x86_64-pc-windows-gnu
           cargo build -p home-http --release --target x86_64-pc-windows-gnu
+          cargo build -p home-oidc --release --target x86_64-pc-windows-gnu
           ls -lah target/x86_64-pc-windows-gnu/release
           mkdir -p services-win
           cp target/x86_64-pc-windows-gnu/release/home-dns.exe   services-win/
           cp target/x86_64-pc-windows-gnu/release/home-http.exe services-win/
+          cp target/x86_64-pc-windows-gnu/release/home-oidc.exe services-win/
 
       - name: Upload services artifacts
         uses: actions/upload-artifact@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,6 +1999,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "home-oidc"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "flexi_logger",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "jsonwebtoken",
+ "log",
+ "once_cell",
+ "rand 0.8.5",
+ "rcgen",
+ "rsa",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "serde_with",
+ "sha2",
+ "tempfile",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "url",
+ "windows-service",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,38 +3260,6 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "objc2-javascript-core",
  "objc2-security",
-]
-
-[[package]]
-name = "oidc-service"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "flexi_logger",
- "http 1.3.1",
- "http-body-util",
- "hyper 1.7.0",
- "hyper-util",
- "jsonwebtoken",
- "log",
- "once_cell",
- "rand 0.8.5",
- "rcgen",
- "rsa",
- "rustls",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "serde_with",
- "sha2",
- "tempfile",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "url",
- "windows-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [
   "home-dns",
   "home-http",
-  "oidc-service",
+  "home-oidc",
   "home-lab/src-tauri",
   "pipe-test",
   "service-tester"

--- a/home-lab/src-tauri/resources/conf/oidc-config.json
+++ b/home-lab/src-tauri/resources/conf/oidc-config.json
@@ -1,0 +1,28 @@
+{
+  "http_port": 8000,
+  "https_port": 8443,
+  "issuer": "https://127.0.0.1:8443",
+  "audiences": [
+    "https://example-app"
+  ],
+  "clients": [
+    {
+      "client_id": "example-client",
+      "client_secret": "change-me",
+      "allowed_scopes": [
+        "openid"
+      ],
+      "password_users": [
+        {
+          "username": "admin",
+          "password": "change-me",
+          "scopes": [
+            "openid"
+          ]
+        }
+      ]
+    }
+  ],
+  "token_ttl_secs": 3600,
+  "log_level": "info"
+}

--- a/home-lab/src-tauri/resources/install-services.nsh
+++ b/home-lab/src-tauri/resources/install-services.nsh
@@ -3,6 +3,7 @@ Var LOG_FILE
 Var LOG_HANDLE
 Var UNINS_HTTP_OK
 Var UNINS_DNS_OK
+Var UNINS_OIDC_OK
 
 !macro NSIS_HOOK_PREINSTALL
   ; SetDetailsPrint is valid in sections; ShowInstDetails must be outside.
@@ -28,6 +29,10 @@ Var UNINS_DNS_OK
     ; Si, pour une raison X, la ressource n'a pas été copiée :
     CopyFiles /SILENT "$INSTDIR\http.yaml" "$INSTDIR\conf\http.yaml"
   ${EndIf}
+  ${IfNot} ${FileExists} "$INSTDIR\conf\oidc-config.json"
+    ; Si, pour une raison X, la ressource n'a pas été copiée :
+    CopyFiles /SILENT "$INSTDIR\oidc-config.json" "$INSTDIR\conf\oidc-config.json"
+  ${EndIf}
   DetailPrint "Installing Windows services..."
   nsExec::ExecToStack '"$INSTDIR\bin\home-dns.exe" install'
   Pop $0
@@ -47,6 +52,15 @@ Var UNINS_DNS_OK
   ${EndIf}
   StrCmp $LOG_HANDLE "" +2
   FileWrite $LOG_HANDLE "home-http.exe install => rc=$0 out=$1$\r$\n"
+  nsExec::ExecToStack '"$INSTDIR\bin\home-oidc.exe" install'
+  Pop $0
+  Pop $1
+  DetailPrint "home-oidc.exe install => rc=$0 out=$1"
+  ${If} $0 != 0
+    DetailPrint "[WARN] home-oidc.exe install returned $0"
+  ${EndIf}
+  StrCmp $LOG_HANDLE "" +2
+  FileWrite $LOG_HANDLE "home-oidc.exe install => rc=$0 out=$1$\r$\n"
   ; Try starting services right after install (best effort)
   nsExec::ExecToStack 'sc.exe start HomeDnsService'
   Pop $0
@@ -60,6 +74,12 @@ Var UNINS_DNS_OK
   DetailPrint "sc start HomeHttpService => rc=$0 out=$1"
   StrCmp $LOG_HANDLE "" +2
   FileWrite $LOG_HANDLE "sc start HomeHttpService => rc=$0 out=$1$\r$\n"
+  nsExec::ExecToStack 'sc.exe start HomeOidcService'
+  Pop $0
+  Pop $1
+  DetailPrint "sc start HomeOidcService => rc=$0 out=$1"
+  StrCmp $LOG_HANDLE "" +2
+  FileWrite $LOG_HANDLE "sc start HomeOidcService => rc=$0 out=$1$\r$\n"
     ; Exécution après installation
   ; Forcer l’élévation (si pas déjà perMachine)
   ; et lancer WSL sans distribution
@@ -91,6 +111,7 @@ Var UNINS_DNS_OK
   ; Track per-service uninstall success to avoid duplicate sc.exe calls
   StrCpy $UNINS_HTTP_OK 0
   StrCpy $UNINS_DNS_OK 0
+  StrCpy $UNINS_OIDC_OK 0
 
   DetailPrint "Invoking service uninstallers..."
   ${If} ${FileExists} "$INSTDIR\bin\home-http.exe"
@@ -102,6 +123,17 @@ Var UNINS_DNS_OK
     FileWrite $LOG_HANDLE "home-http.exe uninstall => rc=$0 out=$1$\r$\n"
     ${If} $0 == 0
       StrCpy $UNINS_HTTP_OK 1
+    ${EndIf}
+  ${EndIf}
+  ${If} ${FileExists} "$INSTDIR\bin\home-oidc.exe"
+    nsExec::ExecToStack '"$INSTDIR\bin\home-oidc.exe" uninstall'
+    Pop $0
+    Pop $1
+    DetailPrint "home-oidc.exe uninstall => rc=$0 out=$1"
+    StrCmp $LOG_HANDLE "" +2
+    FileWrite $LOG_HANDLE "home-oidc.exe uninstall => rc=$0 out=$1$\r$\n"
+    ${If} $0 == 0
+      StrCpy $UNINS_OIDC_OK 1
     ${EndIf}
   ${EndIf}
   ${If} ${FileExists} "$INSTDIR\bin\home-dns.exe"
@@ -126,6 +158,15 @@ Var UNINS_DNS_OK
     StrCmp $LOG_HANDLE "" +2
     FileWrite $LOG_HANDLE "sc stop HomeHttpService => rc=$0 out=$1$\r$\n"
   ${EndIf}
+  ${If} $UNINS_OIDC_OK != 1
+    DetailPrint "Stopping HomeOidcService (fallback)..."
+    nsExec::ExecToStack 'sc.exe stop HomeOidcService'
+    Pop $0
+    Pop $1
+    DetailPrint "sc stop HomeOidcService => rc=$0 out=$1"
+    StrCmp $LOG_HANDLE "" +2
+    FileWrite $LOG_HANDLE "sc stop HomeOidcService => rc=$0 out=$1$\r$\n"
+  ${EndIf}
   ${If} $UNINS_DNS_OK != 1
     DetailPrint "Stopping HomeDnsService (fallback)..."
     nsExec::ExecToStack 'sc.exe stop HomeDnsService'
@@ -138,6 +179,9 @@ Var UNINS_DNS_OK
 
   ; Small grace period if we had to stop via SCM
   ${If} $UNINS_HTTP_OK != 1
+    Sleep 400
+  ${EndIf}
+  ${If} $UNINS_OIDC_OK != 1
     Sleep 400
   ${EndIf}
   ${If} $UNINS_DNS_OK != 1
@@ -180,6 +224,15 @@ Var UNINS_DNS_OK
     DetailPrint "sc delete homehttp => rc=$0 out=$1"
     StrCmp $LOG_HANDLE "" +2
     FileWrite $LOG_HANDLE "sc delete homehttp => rc=$0 out=$1$\r$\n"
+  ${EndIf}
+  ${If} $UNINS_OIDC_OK != 1
+    DetailPrint "Deleting HomeOidcService (fallback)..."
+    nsExec::ExecToStack 'sc.exe delete HomeOidcService'
+    Pop $0
+    Pop $1
+    DetailPrint "sc delete HomeOidcService => rc=$0 out=$1"
+    StrCmp $LOG_HANDLE "" +2
+    FileWrite $LOG_HANDLE "sc delete HomeOidcService => rc=$0 out=$1$\r$\n"
   ${EndIf}
 
   ${If} $UNINS_DNS_OK != 1

--- a/home-lab/src-tauri/resources/install-services.wxs
+++ b/home-lab/src-tauri/resources/install-services.wxs
@@ -7,26 +7,32 @@
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <!--
-    WiX fragment to install/uninstall and start the home-dns/home-http services.
+    WiX fragment to install/uninstall and start the home-dns/home-http/home-oidc services.
     We invoke the bundled executables directly (install|uninstall),
     because tauri-bundler resource files do not have stable Ids we can reference via ServiceInstall.
   -->
 
   <Fragment>
-    <!-- Post-install: run "home-dns.exe install" and "home-http.exe install", then start them -->
+    <!-- Post-install: run "home-dns.exe install", "home-http.exe install" and "home-oidc.exe install", then start them -->
     <CustomAction Id="InstallHomeDns" Directory="INSTALLDIR" Execute="deferred" Impersonate="no"
                   ExeCommand='"[INSTALLDIR]bin\home-dns.exe" install' Return="check" />
     <CustomAction Id="InstallHomeHttp" Directory="INSTALLDIR" Execute="deferred" Impersonate="no"
                   ExeCommand='"[INSTALLDIR]bin\home-http.exe" install' Return="check" />
+    <CustomAction Id="InstallHomeOidc" Directory="INSTALLDIR" Execute="deferred" Impersonate="no"
+                  ExeCommand='"[INSTALLDIR]bin\home-oidc.exe" install' Return="check" />
     <CustomAction Id="StartHomeDns" Directory="INSTALLDIR" Execute="deferred" Impersonate="no"
                   ExeCommand='[SystemFolder]sc.exe start HomeDnsService' Return="ignore" />
     <CustomAction Id="StartHomeHttp" Directory="INSTALLDIR" Execute="deferred" Impersonate="no"
                   ExeCommand='[SystemFolder]sc.exe start HomeHttpService' Return="ignore" />
+    <CustomAction Id="StartHomeOidc" Directory="INSTALLDIR" Execute="deferred" Impersonate="no"
+                  ExeCommand='[SystemFolder]sc.exe start HomeOidcService' Return="ignore" />
     <!-- Uninstall: prefer binary uninstallers; rely on ServiceControl as safety net -->
     <CustomAction Id="UninstallHomeDns" Directory="INSTALLDIR" Execute="deferred" Impersonate="no"
                   ExeCommand='"[INSTALLDIR]bin\home-dns.exe" uninstall' Return="ignore" />
     <CustomAction Id="UninstallHomeHttp" Directory="INSTALLDIR" Execute="deferred" Impersonate="no"
                   ExeCommand='"[INSTALLDIR]bin\home-http.exe" uninstall' Return="ignore" />
+    <CustomAction Id="UninstallHomeOidc" Directory="INSTALLDIR" Execute="deferred" Impersonate="no"
+                  ExeCommand='"[INSTALLDIR]bin\home-oidc.exe" uninstall' Return="ignore" />
 
     <!-- Optional traces to [INSTALLDIR]installer-msi.log to help debug inclusion -->
     <CustomAction Id="TraceInstallServices" Directory="INSTALLDIR"
@@ -45,8 +51,11 @@
       <Custom Action="TraceAfterInstallFiles" Before="InstallHomeDns">NOT Installed</Custom>
       <Custom Action="InstallHomeDns" After="InstallFiles"><![CDATA[NOT (REMOVE = "ALL")]]></Custom>
       <Custom Action="InstallHomeHttp" After="InstallHomeDns"><![CDATA[NOT (REMOVE = "ALL")]]></Custom>
-      <Custom Action="StartHomeDns" After="InstallHomeHttp"><![CDATA[NOT (REMOVE = "ALL")]]></Custom>
+      <Custom Action="InstallHomeOidc" After="InstallHomeHttp"><![CDATA[NOT (REMOVE = "ALL")]]></Custom>
+      <Custom Action="StartHomeDns" After="InstallHomeOidc"><![CDATA[NOT (REMOVE = "ALL")]]></Custom>
       <Custom Action="StartHomeHttp" After="StartHomeDns"><![CDATA[NOT (REMOVE = "ALL")]]></Custom>
+      <Custom Action="StartHomeOidc" After="StartHomeHttp"><![CDATA[NOT (REMOVE = "ALL")]]></Custom>
+      <Custom Action="UninstallHomeOidc" Before="RemoveFiles">(REMOVE = "ALL")</Custom>
       <Custom Action="UninstallHomeHttp" Before="RemoveFiles">(REMOVE = "ALL")</Custom>
       <Custom Action="UninstallHomeDns" Before="RemoveFiles">(REMOVE = "ALL")</Custom>
     </InstallExecuteSequence>
@@ -60,6 +69,7 @@
         <!-- Make sure uninstall always stops and deletes services, even if CAs did not run -->
         <ServiceControl Id="SvcCtl_StopDelete_HomeDns" Name="HomeDnsService" Stop="both" Remove="uninstall" Wait="yes" />
         <ServiceControl Id="SvcCtl_StopDelete_HomeHttp" Name="HomeHttpService" Stop="both" Remove="uninstall" Wait="yes" />
+        <ServiceControl Id="SvcCtl_StopDelete_HomeOidc" Name="HomeOidcService" Stop="both" Remove="uninstall" Wait="yes" />
       </Component>
     </DirectoryRef>
 
@@ -74,10 +84,13 @@
     <FeatureRef Id="ServicesFeature" />
     <CustomActionRef Id="InstallHomeDns" />
     <CustomActionRef Id="InstallHomeHttp" />
+    <CustomActionRef Id="InstallHomeOidc" />
     <CustomActionRef Id="StartHomeDns" />
     <CustomActionRef Id="StartHomeHttp" />
+    <CustomActionRef Id="StartHomeOidc" />
     <CustomActionRef Id="UninstallHomeDns" />
     <CustomActionRef Id="UninstallHomeHttp" />
+    <CustomActionRef Id="UninstallHomeOidc" />
     <CustomActionRef Id="TraceInstallServices" />
     <CustomActionRef Id="TraceAfterInstallFiles" />
     <CustomActionRef Id="TraceUninstallServices" />

--- a/home-oidc/Cargo.toml
+++ b/home-oidc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "oidc-service"
+name = "home-oidc"
 version = "0.1.0"
 edition = "2021"
 license = "GPL-3.0-only"

--- a/home-oidc/src/main.rs
+++ b/home-oidc/src/main.rs
@@ -61,12 +61,12 @@ use windows_service::{
     service_manager::{ServiceInfo, ServiceManager, ServiceManagerAccess},
 };
 
-const SERVICE_NAME: &str = "OidcService";
-const SERVICE_DISPLAY_NAME: &str = "OIDC Service";
+const SERVICE_NAME: &str = "HomeOidcService";
+const SERVICE_DISPLAY_NAME: &str = "Home OIDC Service";
 const SERVICE_DESCRIPTION: &str = "Minimal HTTPS OIDC provider with HTTP mirror";
 
 fn program_data_dir() -> PathBuf {
-    PathBuf::from(r"C:\\ProgramData\\oidc-service\\oidc")
+    PathBuf::from(r"C:\\ProgramData\\home-oidc\\oidc")
 }
 
 fn logs_dir() -> PathBuf {
@@ -195,7 +195,7 @@ fn init_logger(level: log::LevelFilter) -> Result<()> {
         .log_to_file(
             FileSpec::default()
                 .directory(dir)
-                .basename("oidc-service")
+                .basename("home-oidc")
                 .suffix("log"),
         )
         .duplicate_to_stderr(Duplicate::Error)
@@ -1023,7 +1023,7 @@ fn run_service() -> Result<()> {
 
 #[cfg(windows)]
 fn usage() {
-    eprintln!("Usage: oidc-service [run|install|uninstall|console]");
+    eprintln!("Usage: home-oidc [run|install|uninstall|console]");
 }
 
 #[cfg(windows)]

--- a/scripts/after-reboot-setup.ps1
+++ b/scripts/after-reboot-setup.ps1
@@ -31,13 +31,13 @@ if (-not $SkipBuild) {
 
 # Make sure services are Auto and started
 Write-Host '=== Enable + start services (best-effort) ==='
-foreach ($n in 'HomeDnsService','HomeHttpService') {
+foreach ($n in 'HomeDnsService','HomeHttpService','HomeOidcService') {
   try { sc.exe config $n start= auto | Out-Null } catch {}
   try { sc.exe start  $n          | Out-Null } catch {}
 }
 
 Start-Sleep -Seconds 2
-Get-Service HomeDnsService, HomeHttpService -ErrorAction SilentlyContinue |
+Get-Service HomeDnsService, HomeHttpService, HomeOidcService -ErrorAction SilentlyContinue |
   Select Name,Status,StartType | Format-Table -AutoSize | Out-String | Write-Host
 
 # Tail logs for DNS
@@ -47,6 +47,22 @@ if (Test-Path $dnsLog) {
   Get-Content $dnsLog -Tail 120 | ForEach-Object { $_ }
 } else {
   Write-Host "Log file not found: $dnsLog"
+}
+
+$httpLog = 'C:\ProgramData\home-http\logs\home-http_rCURRENT.log'
+if (Test-Path $httpLog) {
+  Write-Host '--- tail home-http_rCURRENT.log ---'
+  Get-Content $httpLog -Tail 120 | ForEach-Object { $_ }
+} else {
+  Write-Host "Log file not found: $httpLog"
+}
+
+$oidcLog = 'C:\ProgramData\home-oidc\oidc\logs\home-oidc_rCURRENT.log'
+if (Test-Path $oidcLog) {
+  Write-Host '--- tail home-oidc_rCURRENT.log ---'
+  Get-Content $oidcLog -Tail 120 | ForEach-Object { $_ }
+} else {
+  Write-Host "Log file not found: $oidcLog"
 }
 
 Write-Host 'Done.'

--- a/scripts/install-elevated.ps1
+++ b/scripts/install-elevated.ps1
@@ -105,9 +105,11 @@ if ($UseMsi) {
 $bin = 'C:\Program Files\home-lab\bin'
 Ensure-Service -Name 'HomeDnsService'  -Exe (Join-Path $bin 'home-dns.exe')  -Args 'install'
 Ensure-Service -Name 'HomeHttpService' -Exe (Join-Path $bin 'home-http.exe') -Args 'install'
+Ensure-Service -Name 'HomeOidcService' -Exe (Join-Path $bin 'home-oidc.exe') -Args 'install'
 
 Write-Host "--- Service status ---"
-Get-Service -Name HomeDnsService, HomeHttpService -ErrorAction SilentlyContinue | Select-Object Name, Status, StartType | Format-Table -AutoSize
+Get-Service -Name HomeDnsService, HomeHttpService, HomeOidcService -ErrorAction SilentlyContinue |
+  Select-Object Name, Status, StartType | Format-Table -AutoSize
 
 Write-Host "--- Recent logs ---"
 if (Test-Path 'C:\ProgramData\home-dns\logs\home-dns_rCURRENT.log') {
@@ -115,6 +117,9 @@ if (Test-Path 'C:\ProgramData\home-dns\logs\home-dns_rCURRENT.log') {
 }
 if (Test-Path 'C:\ProgramData\home-http\logs\home-http_rCURRENT.log') {
   Write-Host '[home-http]'; Get-Content 'C:\ProgramData\home-http\logs\home-http_rCURRENT.log' -Tail 20
+}
+if (Test-Path 'C:\ProgramData\home-oidc\oidc\logs\home-oidc_rCURRENT.log') {
+  Write-Host '[home-oidc]'; Get-Content 'C:\ProgramData\home-oidc\oidc\logs\home-oidc_rCURRENT.log' -Tail 20
 }
 
 Write-Host "Done."


### PR DESCRIPTION
## Summary
- rename the OIDC workspace member to home-oidc and update the Windows service metadata and paths
- bundle the new service into the Tauri installer resources with NSIS/WiX hooks and a default configuration file
- update CI and helper scripts so home-oidc is built and managed alongside the existing services

## Testing
- cargo check *(fails: sysinfo@0.37.2 requires rustc 1.88 while runner has 1.87)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69106d6636848320a90dcb16e5dce3b1)