### PR TITLE
Add Windows service integration test for home-oidc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert_cmd"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +555,17 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -1034,6 +1060,12 @@ dependencies = [
  "rustc_version",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -2003,6 +2035,7 @@ name = "home-oidc"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "base64 0.22.1",
  "flexi_logger",
  "http 1.3.1",
@@ -3707,6 +3740,33 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -5470,6 +5530,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6318,6 +6384,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
+ "libc",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
  "libc",
 ]
 

--- a/home-oidc/Cargo.toml
+++ b/home-oidc/Cargo.toml
@@ -34,4 +34,5 @@ url = "2.5"
 windows-service = { workspace = true }
 
 [dev-dependencies]
+assert_cmd = "2.0"
 tempfile = "3.10"

--- a/home-oidc/tests/windows_service.rs
+++ b/home-oidc/tests/windows_service.rs
@@ -1,0 +1,108 @@
+#![cfg(target_os = "windows")]
+
+use std::io;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, bail, Context, Result};
+use assert_cmd::cargo::CommandCargoExt;
+use assert_cmd::Command;
+use windows_service::service::{Service, ServiceAccess, ServiceState};
+use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+
+const SERVICE_NAME: &str = "HomeOidcService";
+const WAIT_TIMEOUT: Duration = Duration::from_secs(45);
+
+fn cargo_bin() -> Result<Command> {
+    Ok(Command::cargo_bin("home-oidc").context("build home-oidc binary")?)
+}
+
+fn ensure_service_absent() {
+    if let Ok(manager) = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)
+    {
+        if let Ok(service) = manager.open_service(
+            SERVICE_NAME,
+            ServiceAccess::STOP | ServiceAccess::QUERY_STATUS | ServiceAccess::DELETE,
+        ) {
+            let _ = service.stop();
+            let _ = wait_for_transition(&service, ServiceState::Stopped, Duration::from_secs(10));
+            let _ = service.delete();
+        }
+    }
+}
+
+fn run_cli(args: &[&str]) -> Result<()> {
+    let mut cmd = cargo_bin()?;
+    cmd.args(args);
+    let output = cmd
+        .output()
+        .with_context(|| format!("running home-oidc {:?}", args))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    bail!(
+        "home-oidc {:?} failed: status={:?}\nstdout:{}\nstderr:{}",
+        args,
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn wait_for_transition(service: &Service, desired: ServiceState, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let status = service.query_status()?;
+        if status.current_state == desired {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            bail!(
+                "timeout waiting for {:?}, current={:?}",
+                desired,
+                status.current_state
+            );
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+}
+
+fn open_service(access: ServiceAccess) -> Result<Service> {
+    let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)?;
+    Ok(manager.open_service(SERVICE_NAME, access)?)
+}
+
+fn expect_not_found(err: anyhow::Error) -> Result<()> {
+    if let Some(io_err) = err.downcast_ref::<io::Error>() {
+        if io_err.kind() == io::ErrorKind::NotFound {
+            return Ok(());
+        }
+    }
+    Err(err)
+}
+
+#[test]
+#[ignore = "Requires administrator privileges on Windows to install services"]
+fn install_start_stop_cycle() -> Result<()> {
+    ensure_service_absent();
+
+    run_cli(&["install"])?;
+
+    let service =
+        open_service(ServiceAccess::START | ServiceAccess::STOP | ServiceAccess::QUERY_STATUS)?;
+
+    service.start(&[]).context("start installed service")?;
+    wait_for_transition(&service, ServiceState::Running, WAIT_TIMEOUT)?;
+
+    service.stop().context("stop running service")?;
+    wait_for_transition(&service, ServiceState::Stopped, WAIT_TIMEOUT)?;
+
+    drop(service);
+
+    run_cli(&["uninstall"])?;
+
+    match open_service(ServiceAccess::QUERY_STATUS) {
+        Ok(_) => Err(anyhow!("service still present after uninstall")),
+        Err(err) => expect_not_found(err),
+    }
+}


### PR DESCRIPTION
## Summary
- add a Windows-only integration test that exercises installing, starting, stopping, and uninstalling the home-oidc service
- pull in the assert_cmd dev-dependency and refresh Cargo.lock to support invoking the binary under test

## Testing
- cargo test -p home-oidc

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691766ccd048832089616d7684cb9904)