### PR TITLE
Align home-oidc with rustls 0.23.36 and tokio-rustls 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1316,7 +1316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2096,7 +2096,7 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "rsa",
- "rustls 0.21.12",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2205,7 +2205,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2959,7 +2959,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4133,7 +4133,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.35",
+ "rustls",
  "socket2",
  "thiserror 2.0.17",
  "tokio",
@@ -4154,7 +4154,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.17",
@@ -4174,7 +4174,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4465,7 +4465,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -4638,32 +4638,20 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -4710,14 +4698,14 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.35",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.8",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4725,16 +4713,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -4852,16 +4830,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "seahash"
@@ -5822,7 +5790,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6008,7 +5976,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.35",
+ "rustls",
  "tokio",
 ]
 
@@ -6888,7 +6856,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/home-oidc/Cargo.toml
+++ b/home-oidc/Cargo.toml
@@ -21,7 +21,7 @@ once_cell = "1.19"
 rand = "0.8"
 rcgen = { version = "0.14", features = ["pem"] }
 rsa = { version = "0.9", features = ["pem"] }
-rustls = "0.21"
+rustls = "0.23.36"
 rustls-pemfile = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/home-oidc/src/main.rs
+++ b/home-oidc/src/main.rs
@@ -22,7 +22,8 @@ use rsa::pkcs1::DecodeRsaPrivateKey;
 use rsa::pkcs8::{DecodePrivateKey, EncodePrivateKey, LineEnding};
 use rsa::traits::PublicKeyParts;
 use rsa::RsaPrivateKey;
-use rustls::{Certificate as RustlsCertificate, PrivateKey as RustlsPrivateKey, ServerConfig};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::ServerConfig;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_with::skip_serializing_none;
@@ -395,37 +396,27 @@ fn load_key_material(cfg: &ServiceConfig) -> Result<KeyMaterial> {
 
     let mut cert_reader = BufReader::new(cert_pem.as_bytes());
     let certs = rustls_pemfile::certs(&mut cert_reader)
-        .collect::<Result<Vec<_>, _>>()
+        .collect::<Result<Vec<CertificateDer<'static>>, _>>()
         .context("read rustls certs")?;
     let mut key_reader = BufReader::new(key_pem.as_bytes());
-    let mut keys = rustls_pemfile::pkcs8_private_keys(&mut key_reader)
+    let pkcs8_keys = rustls_pemfile::pkcs8_private_keys(&mut key_reader)
         .collect::<Result<Vec<_>, _>>()
-        .context("read pkcs8 key")?
-        .into_iter()
-        .map(|key| key.secret_pkcs8_der().to_vec())
-        .collect::<Vec<_>>();
-    if keys.is_empty() {
+        .context("read pkcs8 key")?;
+    let key = if let Some(key) = pkcs8_keys.into_iter().next() {
+        PrivateKeyDer::from(key)
+    } else {
         key_reader = BufReader::new(key_pem.as_bytes());
-        keys = rustls_pemfile::rsa_private_keys(&mut key_reader)
+        let rsa_keys = rustls_pemfile::rsa_private_keys(&mut key_reader)
             .collect::<Result<Vec<_>, _>>()
-            .context("read rsa key")?
-            .into_iter()
-            .map(|key| key.secret_pkcs1_der().to_vec())
-            .collect::<Vec<_>>();
-    }
-    if keys.is_empty() {
-        return Err(anyhow!("no private key material"));
-    }
+            .context("read rsa key")?;
+        match rsa_keys.into_iter().next() {
+            Some(key) => PrivateKeyDer::from(key),
+            None => return Err(anyhow!("no private key material")),
+        }
+    };
     let tls_config = ServerConfig::builder()
-        .with_safe_defaults()
         .with_no_client_auth()
-        .with_single_cert(
-            certs
-                .into_iter()
-                .map(|cert| RustlsCertificate(cert.as_ref().to_vec()))
-                .collect(),
-            RustlsPrivateKey(keys[0].clone()),
-        )?;
+        .with_single_cert(certs, key)?;
 
     Ok(KeyMaterial {
         encoding,


### PR DESCRIPTION
### Motivation
- Fix a build-time type/trait mismatch between `rustls` and `tokio-rustls` by using a matching `rustls` version and the corresponding `tokio-rustls` binding.
- Update TLS parsing to use the `rustls 0.23` PKI types so certificate and key material can be passed directly to the `rustls` API.

### Description
- Bumped `home-oidc` dependencies in `home-oidc/Cargo.toml` to `rustls = "0.23.36"` and `tokio-rustls = "0.26"`.
- Reworked TLS loading in `home-oidc/src/main.rs` to import `rustls::pki_types::{CertificateDer, PrivateKeyDer}` and to parse PEM with `rustls-pemfile` into `CertificateDer`/`PrivateKeyDer` values, removing the earlier conversions to `rustls::Certificate`/`rustls::PrivateKey`.
- Construct the TLS config using `ServerConfig::builder().with_no_client_auth().with_single_cert(certs, key)?` with the new PKI types.
- Refreshed `Cargo.lock` to include `rustls v0.23.36` and `tokio-rustls v0.26.4` resolutions.

### Testing
- Ran `cargo check -p home-oidc`, which completed successfully (finished `dev` profile) with warnings only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ab8650c08320b2cfb0d1a5234a66)