### PR TITLE
Fix rsa key rng compatibility

### DIFF
--- a/home-oidc/src/main.rs
+++ b/home-oidc/src/main.rs
@@ -16,8 +16,9 @@ use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
 use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use log::{error, info};
-use rand::{rngs::OsRng, RngCore};
+use rand::{rng, RngCore};
 use rcgen::{CertificateParams, DnType, IsCa, KeyPair, SanType};
+use rsa::rand_core::OsRng;
 use rsa::pkcs1::DecodeRsaPrivateKey;
 use rsa::pkcs8::{DecodePrivateKey, EncodePrivateKey, LineEnding};
 use rsa::traits::PublicKeyParts;
@@ -218,7 +219,7 @@ struct ServiceConfig {
 impl Default for ServiceConfig {
     fn default() -> Self {
         let mut secret = [0u8; 24];
-        rand::thread_rng().fill_bytes(&mut secret);
+        rng().fill_bytes(&mut secret);
         let default_secret = URL_SAFE_NO_PAD.encode(secret);
         ServiceConfig {
             http_port: default_http_port(),


### PR DESCRIPTION
### Motivation
- Fix a build failure caused by incompatible `rand_core` versions and a deprecated RNG API that prevented `RsaPrivateKey::new` from accepting the application's RNG.

### Description
- Update `home-oidc/src/main.rs` to use `rand::rng()` instead of the deprecated `rand::thread_rng()` and import `rsa::rand_core::OsRng` so RSA key generation uses a RNG type compatible with `rsa::RsaPrivateKey::new`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981d304768c8320ad99de0e950384e1)