### PR TITLE
Fix RSA RNG mismatch in Tauri build

### DIFF
--- a/home-lab/src-tauri/Cargo.toml
+++ b/home-lab/src-tauri/Cargo.toml
@@ -45,7 +45,6 @@ tokio-stream = "0.1.15"
 futures-util = "0.3.30"
 pin-project = "1.1.5"
 hyper-util = { version = "0.1", features = ["tokio"] }
-rand = "0.9"
 rsa = { version = "0.9", features = ["pem"] }
 reqwest = { version = "0.13", features = ["json", "stream"] }
 

--- a/home-lab/src-tauri/src/wsl.rs
+++ b/home-lab/src-tauri/src/wsl.rs
@@ -14,9 +14,9 @@ use crate::oidc::{
     StatusOut,
 };
 use anyhow::{anyhow, Context, Result};
-use rand::{rngs::OsRng, RngCore};
 use regex::Regex;
 use rsa::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
+use rsa::rand_core::{OsRng, RngCore};
 use rsa::RsaPrivateKey;
 use serde::Serialize;
 use serde_json::json;


### PR DESCRIPTION
### Motivation
- Résoudre les erreurs de compilation causées par un conflit de versions de `rand_core` où `rand::rngs::OsRng` ne satisfaisait pas les traits requis par `rsa::RsaPrivateKey::new`.

### Description
- Remplace l'import `rand::{rngs::OsRng, RngCore}` par `rsa::rand_core::{OsRng, RngCore}` dans `home-lab/src-tauri/src/wsl.rs` pour utiliser la version de `rand_core` attendue par `rsa`.
- Retire la dépendance directe `rand = "0.9"` du `home-lab/src-tauri/Cargo.toml` car elle n'est plus nécessaire.

### Testing
- Aucun test automatisé n'a été exécuté pendant la modification.
- La modification est limitée aux imports et à la gestion des dépendances et doit permettre au build Tauri d'avancer sans l'erreur `CryptoRng`, à valider via `cargo build` ou dans la CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981d78b3c1c83209a76c721a3370695)