### PR TITLE
Align @tauri-apps/api to 2.9.1 to fix Tauri version mismatch

### DIFF
--- a/home-lab/package-lock.json
+++ b/home-lab/package-lock.json
@@ -8,7 +8,7 @@
       "name": "home-lab",
       "version": "0.1.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.9.0"
+        "@tauri-apps/api": "^2.9.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.12",
@@ -1200,9 +1200,9 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.1.tgz",
+      "integrity": "sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -1545,7 +1545,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browserslist": "^4.28.1",
         "caniuse-lite": "^1.0.30001766",
@@ -1637,7 +1636,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2913,7 +2911,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2941,7 +2938,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",

--- a/home-lab/package.json
+++ b/home-lab/package.json
@@ -24,6 +24,6 @@
     "vite": "^7"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.9.0"
+    "@tauri-apps/api": "^2.9.1"
   }
 }


### PR DESCRIPTION
### Motivation
- Tauri build failed with a package/crate version mismatch (`tauri (v2.9.3)` vs `@tauri-apps/api (v2.10.1)`), so the NPM API package needs to be aligned with the Rust Tauri 2.9.x toolchain to avoid CI/build errors.

### Description
- Update `home-lab/package.json` to require `@tauri-apps/api` `^2.9.1` instead of `^2.9.0` and refresh `home-lab/package-lock.json` to lock the API package at `2.9.1`.
- The lockfile entry for `node_modules/@tauri-apps/api` was changed from `2.10.1` to `2.9.1` and the `package-lock.json` was regenerated accordingly.

### Testing
- Ran `npm view @tauri-apps/api versions --json` to inspect available versions and confirm `2.9.1` is published, which succeeded. 
- Ran `cd home-lab && npm install @tauri-apps/api@2.9.1` to update dependencies and the lockfile, which completed successfully and produced the updated `package-lock.json` (no automated test suite was run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69824026c0d48320a3518d0e28d20f82)