### PR TITLE
Fix build: import `rand::Rng` in home-oidc

### DIFF
--- a/home-oidc/src/main.rs
+++ b/home-oidc/src/main.rs
@@ -16,7 +16,7 @@ use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
 use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use log::{error, info};
-use rand::{rng, RngCore};
+use rand::{rng, Rng};
 use rcgen::{CertificateParams, DnType, IsCa, KeyPair, SanType};
 use rsa::rand_core::OsRng;
 use rsa::pkcs1::DecodeRsaPrivateKey;


### PR DESCRIPTION
### Motivation
- Corriger l'erreur de compilation causée par l'import introuvable `rand::RngCore` et permettre l'utilisation de `rng().fill_bytes(...)` avec la version `rand` 0.10.

### Description
- Remplacement de l'import `rand::{rng, RngCore}` par `rand::{rng, Rng}` dans `home-oidc/src/main.rs` pour importer le bon trait requis par `fill_bytes`.

### Testing
- Exécution de `cargo build -p home-oidc --release`, qui s'est terminée avec succès (la compilation produit uniquement quelques warnings d'imports non utilisés déjà présents).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989aa79d5d88320afd946b04359936c)