### PR TITLE
Add S3 bucket browser and persist full Windows source path

### DIFF
--- a/home-lab/src-tauri/proto/home_s3.proto
+++ b/home-lab/src-tauri/proto/home_s3.proto
@@ -21,9 +21,24 @@ message ListBucketsResponse {
   message Bucket {
     string name = 1;
     string created_at = 2;
+    string source_path = 3;
   }
 
   repeated Bucket buckets = 1;
+}
+
+message ListBucketObjectsRequest {
+  string bucket_name = 1;
+}
+
+message ListBucketObjectsResponse {
+  message ObjectEntry {
+    string key = 1;
+    int64 size = 2;
+    string last_modified = 3;
+  }
+
+  repeated ObjectEntry objects = 1;
 }
 
 message CreateBucketRequest {
@@ -48,6 +63,7 @@ service HomeS3 {
   rpc ReloadConfig(Empty) returns (Acknowledge);
   rpc StopService(Empty) returns (Acknowledge);
   rpc ListBuckets(Empty) returns (ListBucketsResponse);
+  rpc ListBucketObjects(ListBucketObjectsRequest) returns (ListBucketObjectsResponse);
   rpc CreateBucket(CreateBucketRequest) returns (Acknowledge);
   rpc UpdateBucket(UpdateBucketRequest) returns (Acknowledge);
   rpc DeleteBucket(DeleteBucketRequest) returns (Acknowledge);

--- a/home-lab/src-tauri/src/lib.rs
+++ b/home-lab/src-tauri/src/lib.rs
@@ -257,6 +257,7 @@ pub fn run() {
             s3::s3_reload_config,
             s3::s3_stop_service,
             s3::s3_list_buckets,
+            s3::s3_list_bucket_objects,
             s3::s3_create_bucket,
             s3::s3_update_bucket,
             s3::s3_delete_bucket,

--- a/home-lab/src-tauri/src/s3.rs
+++ b/home-lab/src-tauri/src/s3.rs
@@ -24,7 +24,8 @@ mod proto {
 
 use proto::homes3::v1::home_s3_client::HomeS3Client;
 use proto::homes3::v1::{
-    Acknowledge, CreateBucketRequest, DeleteBucketRequest, Empty, UpdateBucketRequest,
+    Acknowledge, CreateBucketRequest, DeleteBucketRequest, Empty, ListBucketObjectsRequest,
+    UpdateBucketRequest,
 };
 
 const PIPE_RELEASE: &str = r"\\.\pipe\home-s3";
@@ -242,11 +243,24 @@ pub struct StatusOut {
 pub struct BucketOut {
     pub name: String,
     pub created_at: String,
+    pub source_path: String,
 }
 
 #[derive(Serialize)]
 pub struct ListBucketsOut {
     pub buckets: Vec<BucketOut>,
+}
+
+#[derive(Serialize)]
+pub struct BucketObjectOut {
+    pub key: String,
+    pub size: i64,
+    pub last_modified: String,
+}
+
+#[derive(Serialize)]
+pub struct ListBucketObjectsOut {
+    pub objects: Vec<BucketObjectOut>,
 }
 
 impl From<Acknowledge> for AckOut {
@@ -314,9 +328,31 @@ pub async fn s3_list_buckets() -> Result<ListBucketsOut, String> {
         .map(|bucket| BucketOut {
             name: bucket.name,
             created_at: bucket.created_at,
+            source_path: bucket.source_path,
         })
         .collect();
     Ok(ListBucketsOut { buckets })
+}
+
+#[tauri::command]
+#[instrument(level = "debug")]
+pub async fn s3_list_bucket_objects(bucket_name: String) -> Result<ListBucketObjectsOut, String> {
+    let mut client = connect_client().await?;
+    let response = client
+        .list_bucket_objects(ListBucketObjectsRequest { bucket_name })
+        .await
+        .map_err(|err| err.to_string())?;
+    let list = response.into_inner();
+    let objects = list
+        .objects
+        .into_iter()
+        .map(|object| BucketObjectOut {
+            key: object.key,
+            size: object.size,
+            last_modified: object.last_modified,
+        })
+        .collect();
+    Ok(ListBucketObjectsOut { objects })
 }
 
 #[tauri::command]

--- a/home-lab/src/components/s3-buckets.js
+++ b/home-lab/src/components/s3-buckets.js
@@ -1,6 +1,7 @@
 import {
   s3_create_bucket,
   s3_delete_bucket,
+  s3_list_bucket_objects,
   s3_list_buckets,
   s3_update_bucket,
 } from '../tauri.js';
@@ -17,6 +18,24 @@ function formatDate(value) {
   return parsed.toLocaleString();
 }
 
+function formatBytes(value) {
+  const size = Number(value);
+  if (!Number.isFinite(size) || size < 0) {
+    return 'taille inconnue';
+  }
+  if (size < 1024) {
+    return `${size} B`;
+  }
+  const units = ['Ko', 'Mo', 'Go', 'To'];
+  let current = size / 1024;
+  let unitIndex = 0;
+  while (current >= 1024 && unitIndex < units.length - 1) {
+    current /= 1024;
+    unitIndex += 1;
+  }
+  return `${current.toFixed(current >= 10 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
 class S3Buckets extends HTMLElement {
   constructor() {
     super();
@@ -25,6 +44,9 @@ class S3Buckets extends HTMLElement {
     this._lastError = null;
     this._buckets = [];
     this._editingBucket = null;
+    this._objectsByBucket = {};
+    this._loadingObjects = {};
+    this._expandedBuckets = {};
   }
 
   connectedCallback() {
@@ -73,7 +95,30 @@ class S3Buckets extends HTMLElement {
       return '<li class="text-sm text-gray-600">Aucun bucket.</li>';
     }
     return this._buckets
-      .map((bucket) => `
+      .map((bucket) => {
+        const isExpanded = !!this._expandedBuckets[bucket.name];
+        const isLoadingObjects = !!this._loadingObjects[bucket.name];
+        const objects = this._objectsByBucket[bucket.name];
+        const sourcePath = bucket.source_path?.trim()
+          ? `<p class="text-xs text-gray-500 break-all">Dossier Windows monté: <code>${bucket.source_path}</code></p>`
+          : '<p class="text-xs text-gray-400">Aucun dossier Windows source enregistré.</p>';
+        const objectsPanel = !isExpanded
+          ? ''
+          : `
+            <div class="mt-3 rounded border border-gray-200 bg-white p-3">
+              <div class="flex items-center justify-between gap-2">
+                <h4 class="font-medium text-sm">Contenu du bucket</h4>
+                <button
+                  type="button"
+                  class="s3-reload-objects text-xs text-blue-600 hover:text-blue-800"
+                  data-name="${bucket.name}"
+                >Actualiser le contenu</button>
+              </div>
+              ${isLoadingObjects
+                ? '<p class="mt-2 text-sm text-gray-500">Chargement des objets...</p>'
+                : this.renderObjectsList(bucket.name, objects)}
+            </div>`;
+        return `
         <li
           class="border-b border-gray-200 pb-3 mb-3 last:pb-0 last:mb-0 last:border-none"
           data-bucket-row
@@ -83,8 +128,14 @@ class S3Buckets extends HTMLElement {
             <div>
               <span class="font-semibold">${bucket.name}</span>
               <p class="text-xs text-gray-500">Créé le: ${formatDate(bucket.created_at)}</p>
+              ${sourcePath}
             </div>
             <div class="flex items-center gap-2">
+              <button
+                type="button"
+                class="s3-toggle-objects text-xs text-slate-700 hover:text-slate-900"
+                data-name="${bucket.name}"
+              >${isExpanded ? 'Masquer le contenu' : 'Voir le contenu'}</button>
               <button
                 type="button"
                 class="s3-edit-bucket text-xs text-blue-600 hover:text-blue-800"
@@ -101,8 +152,41 @@ class S3Buckets extends HTMLElement {
             <input type="checkbox" class="s3-delete-objects" />
             Supprimer aussi les objets du bucket
           </label>
-        </li>`)
+          ${objectsPanel}
+        </li>`;
+      })
       .join('');
+  }
+
+  renderObjectsList(bucketName, objects) {
+    if (!Array.isArray(objects)) {
+      return '<p class="mt-2 text-sm text-gray-500">Cliquez sur “Actualiser le contenu” pour charger les objets.</p>';
+    }
+    if (!objects.length) {
+      return `<p class="mt-2 text-sm text-gray-500">Le bucket <code>${bucketName}</code> est vide.</p>`;
+    }
+    return `
+      <div class="mt-2 overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead>
+            <tr class="text-left text-gray-500">
+              <th class="py-1 pr-4 font-medium">Clé objet</th>
+              <th class="py-1 pr-4 font-medium">Taille</th>
+              <th class="py-1 font-medium">Dernière modification</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${objects
+              .map((object) => `
+                <tr class="border-t border-gray-100 align-top">
+                  <td class="py-2 pr-4"><code class="break-all">${object.key}</code></td>
+                  <td class="py-2 pr-4 whitespace-nowrap">${formatBytes(object.size)}</td>
+                  <td class="py-2 whitespace-nowrap">${formatDate(object.last_modified)}</td>
+                </tr>`)
+              .join('')}
+          </tbody>
+        </table>
+      </div>`;
   }
 
   renderCreateForm() {
@@ -155,6 +239,7 @@ class S3Buckets extends HTMLElement {
           <input
             name="source_path"
             type="text"
+            value="${bucket.source_path || ''}"
             placeholder="Chemin Windows à importer (optionnel)"
             class="rounded border border-gray-300 px-2 py-1"
           />
@@ -173,6 +258,22 @@ class S3Buckets extends HTMLElement {
 
   renderSuccess(buckets) {
     this._buckets = Array.isArray(buckets) ? buckets : [];
+    const knownBuckets = new Set(this._buckets.map((bucket) => bucket.name));
+    Object.keys(this._objectsByBucket).forEach((bucketName) => {
+      if (!knownBuckets.has(bucketName)) {
+        delete this._objectsByBucket[bucketName];
+      }
+    });
+    Object.keys(this._loadingObjects).forEach((bucketName) => {
+      if (!knownBuckets.has(bucketName)) {
+        delete this._loadingObjects[bucketName];
+      }
+    });
+    Object.keys(this._expandedBuckets).forEach((bucketName) => {
+      if (!knownBuckets.has(bucketName)) {
+        delete this._expandedBuckets[bucketName];
+      }
+    });
     if (this._editingBucket && !this.editingBucket) {
       this._editingBucket = null;
     }
@@ -229,6 +330,12 @@ class S3Buckets extends HTMLElement {
     });
     this.querySelectorAll('.s3-delete-bucket').forEach((button) => {
       button.addEventListener('click', (event) => this.handleDelete(event));
+    });
+    this.querySelectorAll('.s3-toggle-objects').forEach((button) => {
+      button.addEventListener('click', (event) => this.handleToggleObjects(event));
+    });
+    this.querySelectorAll('.s3-reload-objects').forEach((button) => {
+      button.addEventListener('click', (event) => this.handleReloadObjects(event));
     });
   }
 
@@ -345,6 +452,9 @@ class S3Buckets extends HTMLElement {
       if (this._editingBucket === bucket_name) {
         this._editingBucket = null;
       }
+      delete this._expandedBuckets[bucket_name];
+      delete this._objectsByBucket[bucket_name];
+      delete this._loadingObjects[bucket_name];
       await this.load();
       showSuccess(result?.message || `Bucket ${bucket_name} supprimé.`);
     } catch (err) {
@@ -352,6 +462,43 @@ class S3Buckets extends HTMLElement {
       button.textContent = 'Supprimer';
       showError(err?.message || String(err));
     }
+  }
+
+  async fetchBucketObjects(bucketName, { silent = false } = {}) {
+    if (!bucketName) {
+      return;
+    }
+    this._loadingObjects[bucketName] = true;
+    this.renderSuccess(this._buckets);
+    try {
+      const objects = await s3_list_bucket_objects({ bucket_name: bucketName });
+      this._objectsByBucket[bucketName] = Array.isArray(objects) ? objects : [];
+    } catch (err) {
+      if (!silent) {
+        showError(err?.message || String(err));
+      }
+    } finally {
+      this._loadingObjects[bucketName] = false;
+      this.renderSuccess(this._buckets);
+    }
+  }
+
+  async handleToggleObjects(event) {
+    const bucketName = event.currentTarget?.dataset?.name;
+    if (!bucketName) {
+      return;
+    }
+    const willExpand = !this._expandedBuckets[bucketName];
+    this._expandedBuckets[bucketName] = willExpand;
+    this.renderSuccess(this._buckets);
+    if (willExpand && !Array.isArray(this._objectsByBucket[bucketName])) {
+      await this.fetchBucketObjects(bucketName);
+    }
+  }
+
+  async handleReloadObjects(event) {
+    const bucketName = event.currentTarget?.dataset?.name;
+    await this.fetchBucketObjects(bucketName);
   }
 
   async load() {

--- a/home-lab/src/tauri.js
+++ b/home-lab/src/tauri.js
@@ -60,9 +60,27 @@ const __MOCK = {
       force_path_style: true,
     },
     buckets: [
-      { name: 'media', created_at: '2026-03-15T08:15:00Z' },
-      { name: 'backups', created_at: '2026-03-15T08:30:00Z' },
+      {
+        name: 'media',
+        created_at: '2026-03-15T08:15:00Z',
+        source_path: 'C:\\Users\\demo\\Media Library',
+      },
+      {
+        name: 'backups',
+        created_at: '2026-03-15T08:30:00Z',
+        source_path: 'D:\\Backups\\Nightly',
+      },
     ],
+    objects: {
+      media: [
+        { key: 'movies/Inception.mkv', size: 4294967296, last_modified: '2026-03-17T22:15:00Z' },
+        { key: 'series/Dark/S01E01.mkv', size: 2147483648, last_modified: '2026-03-16T21:00:00Z' },
+      ],
+      backups: [
+        { key: 'postgres/2026-03-17.sql.gz', size: 15728640, last_modified: '2026-03-17T03:10:00Z' },
+        { key: 'photos/2026-03-17.tar.zst', size: 73400320, last_modified: '2026-03-17T03:12:00Z' },
+      ],
+    },
   },
   oidc: {
     status: {
@@ -199,6 +217,15 @@ async function mockInvoke(cmd, args = {}) {
       return { ok: true, message: 'S3 stopped' };
     case 's3_list_buckets':
       return { buckets: __MOCK.s3.buckets.map((bucket) => ({ ...bucket })) };
+    case 's3_list_bucket_objects': {
+      const name = (args?.bucketName || args?.bucket_name || '').trim().toLowerCase();
+      if (!name) {
+        return { ok: false, message: 'Bucket name required' };
+      }
+      return {
+        objects: (__MOCK.s3.objects[name] || []).map((object) => ({ ...object })),
+      };
+    }
     case 's3_create_bucket': {
       const name = (args?.bucketName || args?.bucket_name || '').trim().toLowerCase();
       const sourcePath = (args?.sourcePath || args?.source_path || '').trim();
@@ -207,7 +234,16 @@ async function mockInvoke(cmd, args = {}) {
       }
       const existed = __MOCK.s3.buckets.some((bucket) => bucket.name === name);
       if (!existed) {
-        __MOCK.s3.buckets.push({ name, created_at: new Date().toISOString() });
+        __MOCK.s3.buckets.push({
+          name,
+          created_at: new Date().toISOString(),
+          source_path: sourcePath,
+        });
+        __MOCK.s3.objects[name] = [];
+      } else if (sourcePath) {
+        __MOCK.s3.buckets = __MOCK.s3.buckets.map((bucket) => (
+          bucket.name === name ? { ...bucket, source_path: sourcePath } : bucket
+        ));
       }
       return {
         ok: true,
@@ -240,6 +276,23 @@ async function mockInvoke(cmd, args = {}) {
         return { ok: false, message: `Bucket ${newName} exists already (mock).` };
       }
       currentBucket.name = newName;
+      if (sourcePath) {
+        currentBucket.source_path = sourcePath;
+      }
+      if (newName !== currentName) {
+        __MOCK.s3.objects[newName] = __MOCK.s3.objects[currentName] || [];
+        delete __MOCK.s3.objects[currentName];
+      }
+      if (replaceObjects) {
+        __MOCK.s3.objects[newName] = sourcePath
+          ? [{ key: 'imported/mock-file.txt', size: 128, last_modified: new Date().toISOString() }]
+          : [];
+      } else if (sourcePath) {
+        __MOCK.s3.objects[newName] = [
+          ...(__MOCK.s3.objects[newName] || []),
+          { key: 'imported/mock-file.txt', size: 128, last_modified: new Date().toISOString() },
+        ];
+      }
       let message = newName !== currentName
         ? `Bucket ${currentName} renamed to ${newName} (mock).`
         : `Bucket ${currentName} updated (mock).`;
@@ -258,6 +311,7 @@ async function mockInvoke(cmd, args = {}) {
       }
       const before = __MOCK.s3.buckets.length;
       __MOCK.s3.buckets = __MOCK.s3.buckets.filter((bucket) => bucket.name !== name);
+      delete __MOCK.s3.objects[name];
       const removed = before !== __MOCK.s3.buckets.length;
       return {
         ok: removed,
@@ -688,6 +742,17 @@ export async function s3_stop_service() {
 export async function s3_list_buckets() {
   const res = await safeInvoke('s3_list_buckets');
   return Array.isArray(res) ? res : (res?.buckets ?? []);
+}
+
+export async function s3_list_bucket_objects(bucketName) {
+  const name = typeof bucketName === 'object' && bucketName !== null
+    ? String(bucketName.bucket_name ?? bucketName.bucketName ?? bucketName.name ?? '').trim()
+    : String(bucketName ?? '').trim();
+  if (!name) throw new Error('Le nom du bucket est requis pour lister son contenu.');
+  const res = await safeInvoke('s3_list_bucket_objects', {
+    bucketName: name,
+  });
+  return Array.isArray(res) ? res : (res?.objects ?? []);
 }
 
 export async function s3_create_bucket(bucketName, sourcePath = '') {

--- a/home-s3/proto/home_s3.proto
+++ b/home-s3/proto/home_s3.proto
@@ -21,9 +21,24 @@ message ListBucketsResponse {
   message Bucket {
     string name = 1;
     string created_at = 2;
+    string source_path = 3;
   }
 
   repeated Bucket buckets = 1;
+}
+
+message ListBucketObjectsRequest {
+  string bucket_name = 1;
+}
+
+message ListBucketObjectsResponse {
+  message ObjectEntry {
+    string key = 1;
+    int64 size = 2;
+    string last_modified = 3;
+  }
+
+  repeated ObjectEntry objects = 1;
 }
 
 message CreateBucketRequest {
@@ -48,6 +63,7 @@ service HomeS3 {
   rpc ReloadConfig(Empty) returns (Acknowledge);
   rpc StopService(Empty) returns (Acknowledge);
   rpc ListBuckets(Empty) returns (ListBucketsResponse);
+  rpc ListBucketObjects(ListBucketObjectsRequest) returns (ListBucketObjectsResponse);
   rpc CreateBucket(CreateBucketRequest) returns (Acknowledge);
   rpc UpdateBucket(UpdateBucketRequest) returns (Acknowledge);
   rpc DeleteBucket(DeleteBucketRequest) returns (Acknowledge);

--- a/home-s3/src/main.rs
+++ b/home-s3/src/main.rs
@@ -104,8 +104,8 @@ mod proto {
 
 use proto::homes3::v1::home_s3_server::{HomeS3, HomeS3Server};
 use proto::homes3::v1::{
-    Acknowledge, CreateBucketRequest, DeleteBucketRequest, Empty, ListBucketsResponse,
-    StatusResponse, UpdateBucketRequest,
+    Acknowledge, CreateBucketRequest, DeleteBucketRequest, Empty, ListBucketObjectsRequest,
+    ListBucketObjectsResponse, ListBucketsResponse, StatusResponse, UpdateBucketRequest,
 };
 
 const SERVICE_NAME: &str = "HomeS3Service";
@@ -207,6 +207,10 @@ fn logs_dir() -> PathBuf {
 
 fn config_path() -> PathBuf {
     program_data_dir().join("s3-config.json")
+}
+
+fn bucket_metadata_path() -> PathBuf {
+    program_data_dir().join("bucket-metadata.json")
 }
 
 fn default_data_dir() -> String {
@@ -357,6 +361,54 @@ fn load_config_or_init() -> Result<ServiceConfig> {
     let cfg: ServiceConfig = serde_json::from_str(&raw).context("parse S3 config")?;
     ensure_data_dir(Path::new(&cfg.data_dir))?;
     Ok(cfg)
+}
+
+fn load_bucket_metadata() -> Result<std::collections::BTreeMap<String, String>> {
+    ensure_layout()?;
+    let path = bucket_metadata_path();
+    if !path.exists() {
+        return Ok(std::collections::BTreeMap::new());
+    }
+    let raw = std_fs::read_to_string(&path).context("read bucket metadata")?;
+    let metadata = serde_json::from_str(&raw).context("parse bucket metadata")?;
+    Ok(metadata)
+}
+
+fn save_bucket_metadata(metadata: &std::collections::BTreeMap<String, String>) -> Result<()> {
+    ensure_layout()?;
+    let path = bucket_metadata_path();
+    let json = serde_json::to_string_pretty(metadata)?;
+    std_fs::write(&path, format!("{json}\n")).context("write bucket metadata")?;
+    Ok(())
+}
+
+fn get_bucket_source_path(bucket: &str) -> Result<Option<String>> {
+    let metadata = load_bucket_metadata()?;
+    Ok(metadata.get(bucket).cloned())
+}
+
+fn set_bucket_source_path(bucket: &str, source_path: Option<&Path>) -> Result<()> {
+    let mut metadata = load_bucket_metadata()?;
+    match source_path {
+        Some(path) => {
+            metadata.insert(bucket.to_string(), path.display().to_string());
+        }
+        None => {
+            metadata.remove(bucket);
+        }
+    }
+    save_bucket_metadata(&metadata)
+}
+
+fn rename_bucket_source_path(current_bucket: &str, new_bucket: &str) -> Result<()> {
+    if current_bucket == new_bucket {
+        return Ok(());
+    }
+    let mut metadata = load_bucket_metadata()?;
+    if let Some(source_path) = metadata.remove(current_bucket) {
+        metadata.insert(new_bucket.to_string(), source_path);
+    }
+    save_bucket_metadata(&metadata)
 }
 
 fn init_logger(level: LevelFilter) -> Result<()> {
@@ -770,7 +822,11 @@ async fn list_bucket_object_keys(client: &Client, bucket: &str) -> Result<Vec<St
     Ok(keys)
 }
 
-async fn copy_bucket_contents(client: &Client, source_bucket: &str, target_bucket: &str) -> Result<usize> {
+async fn copy_bucket_contents(
+    client: &Client,
+    source_bucket: &str,
+    target_bucket: &str,
+) -> Result<usize> {
     let keys = list_bucket_object_keys(client, source_bucket).await?;
     for key in &keys {
         let object = client
@@ -794,7 +850,9 @@ async fn copy_bucket_contents(client: &Client, source_bucket: &str, target_bucke
             .body(ByteStream::from(body))
             .send()
             .await
-            .with_context(|| format!("copy s3://{source_bucket}/{key} to s3://{target_bucket}/{key}"))?;
+            .with_context(|| {
+                format!("copy s3://{source_bucket}/{key} to s3://{target_bucket}/{key}")
+            })?;
     }
     Ok(keys.len())
 }
@@ -835,7 +893,8 @@ async fn update_bucket(
         if replace_objects {
             outcome.cleared_objects = empty_bucket(client, new_bucket).await?;
         } else {
-            outcome.copied_objects = copy_bucket_contents(client, current_bucket, new_bucket).await?;
+            outcome.copied_objects =
+                copy_bucket_contents(client, current_bucket, new_bucket).await?;
         }
 
         if let Some(path) = source_path {
@@ -983,9 +1042,61 @@ impl HomeS3 for HomeS3GrpcService {
                     .creation_date()
                     .map(|value| format!("{value:?}"))
                     .unwrap_or_default(),
+                source_path: get_bucket_source_path(bucket.name().unwrap_or_default())
+                    .ok()
+                    .flatten()
+                    .unwrap_or_default(),
             })
             .collect();
         Ok(GrpcResponse::new(ListBucketsResponse { buckets }))
+    }
+
+    async fn list_bucket_objects(
+        &self,
+        request: GrpcRequest<ListBucketObjectsRequest>,
+    ) -> Result<GrpcResponse<ListBucketObjectsResponse>, Status> {
+        let request = request.into_inner();
+        let bucket = request.bucket_name.trim().to_string();
+        validate_bucket_name(&bucket).map_err(|err| Status::invalid_argument(err.to_string()))?;
+
+        let cfg = current_config(&self.shared).await;
+        let client = make_s3_client(&cfg)
+            .await
+            .map_err(|err| internal_status("initialise S3 client", err))?;
+
+        let mut continuation_token = None::<String>;
+        let mut objects = Vec::new();
+
+        loop {
+            let mut list_request = client.list_objects_v2().bucket(&bucket);
+            if let Some(token) = &continuation_token {
+                list_request = list_request.continuation_token(token);
+            }
+
+            let output = list_request
+                .send()
+                .await
+                .with_context(|| format!("list objects in bucket {bucket} via {}", cfg.endpoint))
+                .map_err(|err| endpoint_status("list bucket objects", &cfg.endpoint, err))?;
+
+            objects.extend(output.contents().iter().map(|object| {
+                proto::homes3::v1::list_bucket_objects_response::ObjectEntry {
+                    key: object.key().unwrap_or_default().to_string(),
+                    size: object.size().unwrap_or_default(),
+                    last_modified: object
+                        .last_modified()
+                        .map(|value| format!("{value:?}"))
+                        .unwrap_or_default(),
+                }
+            }));
+
+            continuation_token = output.next_continuation_token().map(ToOwned::to_owned);
+            if continuation_token.is_none() {
+                break;
+            }
+        }
+
+        Ok(GrpcResponse::new(ListBucketObjectsResponse { objects }))
     }
 
     async fn create_bucket(
@@ -1006,6 +1117,10 @@ impl HomeS3 for HomeS3GrpcService {
             create_bucket_and_import(&client, &bucket, source_path.as_deref())
                 .await
                 .map_err(|err| endpoint_status("create bucket", &cfg.endpoint, err))?;
+        if source_path.is_some() {
+            set_bucket_source_path(&bucket, source_path.as_deref())
+                .map_err(|err| internal_status("persist bucket metadata", err))?;
+        }
 
         let message = match (created, imported) {
             (true, 0) => format!("bucket {bucket} created"),
@@ -1032,7 +1147,8 @@ impl HomeS3 for HomeS3GrpcService {
 
         validate_bucket_name(&current_bucket)
             .map_err(|err| Status::invalid_argument(err.to_string()))?;
-        validate_bucket_name(&new_bucket).map_err(|err| Status::invalid_argument(err.to_string()))?;
+        validate_bucket_name(&new_bucket)
+            .map_err(|err| Status::invalid_argument(err.to_string()))?;
         let source_path = normalize_source_path(&request.source_path)
             .map_err(|err| Status::invalid_argument(err.to_string()))?;
 
@@ -1049,6 +1165,15 @@ impl HomeS3 for HomeS3GrpcService {
         )
         .await
         .map_err(|err| endpoint_status("update bucket", &cfg.endpoint, err))?;
+
+        if outcome.renamed {
+            rename_bucket_source_path(&current_bucket, &new_bucket)
+                .map_err(|err| internal_status("persist bucket metadata", err))?;
+        }
+        if let Some(source_path) = source_path.as_deref() {
+            set_bucket_source_path(&new_bucket, Some(source_path))
+                .map_err(|err| internal_status("persist bucket metadata", err))?;
+        }
 
         let action = if outcome.renamed {
             format!("bucket {current_bucket} updated to {new_bucket}")
@@ -1095,6 +1220,8 @@ impl HomeS3 for HomeS3GrpcService {
         let deleted = delete_bucket(&client, &bucket, request.delete_objects)
             .await
             .map_err(|err| endpoint_status("delete bucket", &cfg.endpoint, err))?;
+        set_bucket_source_path(&bucket, None)
+            .map_err(|err| internal_status("persist bucket metadata", err))?;
         let message = if request.delete_objects {
             format!("bucket {bucket} deleted after removing {deleted} object(s)")
         } else {


### PR DESCRIPTION
### Motivation
- Exposer dans l’IHM le chemin Windows complet du dossier monté pour chaque bucket S3 et permettre de parcourir le contenu des buckets depuis l’interface.
- Étendre le contrat gRPC pour transmettre le `source_path` et lister les objets d’un bucket afin que la couche Tauri/UI puisse afficher ces informations.

### Description
- Étendu le proto Home S3 avec `source_path` dans `ListBucketsResponse` et ajouté `ListBucketObjects`/messages associés (`ListBucketObjectsRequest`, `ListBucketObjectsResponse`). (`home-lab/src-tauri/proto/home_s3.proto`, `home-s3/proto/home_s3.proto`).
- Persisté localement la métadonnée du chemin Windows par bucket dans `home-s3` (`bucket-metadata.json`) et ajouté helpers pour lire/écrire/renommer/supprimer ces métadonnées; mises à jour lors de la création, du renommage et de la suppression de buckets. (`home-s3/src/main.rs`).
- Implémenté sur le service `home-s3` l’endpoint gRPC `ListBucketObjects` pour renvoyer clé/tailles/date de modification et branché la persistance du `source_path` lors des opérations create/update/delete. (`home-s3/src/main.rs`).
- Exposé la nouvelle commande Tauri `s3_list_bucket_objects` et enrichi le bridge Tauri pour retourner `source_path` via `s3_list_buckets`. (`home-lab/src-tauri/src/s3.rs`, `home-lab/src-tauri/src/lib.rs`, `home-lab/src/tauri.js`).
- Mis à jour l’IHM S3 pour afficher le `Dossier Windows monté: <code>…</code>` pour chaque bucket, préremplir le champ `source_path` dans le formulaire d’édition, ajouter un navigateur de contenu (ouvrir / actualiser le contenu d’un bucket) et formater les tailles/dates; mock front mis à jour pour couvrir les nouveaux cas. (`home-lab/src/components/s3-buckets.js`, `home-lab/src/tauri.js`).

### Testing
- `npm run build` in `home-lab` completed successfully (UI build ok).
- `rustfmt` (via `rustfmt --edition 2021`) ran on modified Rust files successfully.
- `cargo check -p home-s3` and `cargo check -p home-lab` could not complete in this environment because the installed `rustc (1.87.0)` is older than the minimum required by several dependencies (AWS SDK / rustfs); failures are environmental and unrelated to the new code contract changes.
- Lint/format and lightweight verification steps completed; UI mock exercised the new flows during development.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba3f35d778832089e2562ee50d101c)