### PR TITLE
Optimize Rust GitHub Actions build caching

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -91,6 +91,18 @@ jobs:
           name: services-win
           path: home-lab/src-tauri/resources/bin
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache Rust (Tauri app)
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: tauri-app-x86_64-pc-windows-msvc
+          cache-on-failure: true
+
       - name: Build Tauri helper binaries into resources/bin
         shell: pwsh
         run: |
@@ -112,18 +124,6 @@ jobs:
           Move-Item -LiteralPath 'home-lab/src-tauri/resources/wsl/env-dev-image.tar' `
                     -Destination 'home-lab/src-tauri/resources/wsl/wsl-rootfs.tar' `
                     -Force
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Cache Rust (Tauri app)
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: tauri-app-x86_64-pc-windows-msvc
-          cache-on-failure: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -1,5 +1,17 @@
 name: Build Tauri
 
+concurrency:
+  group: build-tauri-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_CACHE_SIZE: 2G
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "8"
+  CARGO_PROFILE_RELEASE_LTO: "off"
+  CARGO_PROFILE_RELEASE_OPT_LEVEL: "2"
+
 on:
   push:
     branches-ignore: ['codex/*']
@@ -30,6 +42,9 @@ jobs:
         with:
           targets: x86_64-pc-windows-msvc
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
       - name: Cache Rust (workspace)
         uses: Swatinem/rust-cache@v2
         with:
@@ -39,10 +54,7 @@ jobs:
       - name: Build services (Windows MSVC)
         shell: pwsh
         run: |
-          cargo build -p home-dns   --release
-          cargo build -p home-http --release
-          cargo build -p home-s3   --release
-          cargo build -p home-oidc --release
+          cargo build --release -p home-dns -p home-http -p home-s3 -p home-oidc
           Get-ChildItem target/release -Filter 'home-*.exe'
           New-Item -ItemType Directory -Path services-win -Force | Out-Null
           Copy-Item target/release/home-dns.exe   services-win/ -Force
@@ -104,6 +116,9 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
       - name: Cache Rust (Tauri app)
         uses: Swatinem/rust-cache@v2
         with:
@@ -114,6 +129,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: npm
+          cache-dependency-path: home-lab/package-lock.json
       
       - name: import windows certificate
         if: matrix.platform == 'windows-latest'
@@ -126,23 +143,15 @@ jobs:
           certutil -decode certificate/tempCert.txt certificate/certificate.pfx
           Remove-Item -path certificate -include tempCert.txt
           Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_CERTIFICATE_PASSWORD -Force -AsPlainText)
-      - name: Install frontend deps + Tauri CLI
+      - name: Install frontend deps
         working-directory: home-lab
         shell: pwsh
-        run: |
-          if (Test-Path package-lock.json) { npm ci } else { npm install }
-          $hasCli = (npm pkg get devDependencies.'@tauri-apps/cli' | Select-String -Quiet '@tauri-apps/cli')
-          if (-not $hasCli) { npm i -D @tauri-apps/cli@latest }
-          npx tauri -V
+        run: npm ci
 
-      # Optionnel : cache npm
-      - name: Enable npm cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('home-lab/**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+      - name: Verify Tauri CLI
+        working-directory: home-lab
+        shell: pwsh
+        run: npx tauri -V
 
       - name: Build Tauri (Windows - NSIS + MSI)
         uses: tauri-apps/tauri-action@v0.6.2


### PR DESCRIPTION
### Motivation

- Réduire la durée et le travail inutile des runs CI pour le workflow Tauri/Rust en appliquant des optimisations de cache et de profil de build adaptées au CI.
- Éviter de relancer des builds supersédés et diminuer l'overhead des multiples invocations `cargo` dans le même job.
- Simplifier et fiabiliser la mise en cache des dépendances Node.js pour le front-end.

### Description

- Modifie `.github/workflows/build-tauri.yml` pour ajouter une clé `concurrency` afin d’annuler les runs supersédés et réduire le gaspillage de CI. 
- Active et configure `sccache` via `mozilla-actions/sccache-action@v0.0.9` et injecte des variables d’environnement (`RUSTC_WRAPPER`, `SCCACHE_*`, `CARGO_PROFILE_RELEASE_*`) pour un profil `release` plus rapide en CI.
- Consolide les quatre appels `cargo build -p ... --release` en une seule commande `cargo build --release -p home-dns -p home-http -p home-s3 -p home-oidc` pour réduire l’overhead Cargo et mieux réutiliser le graphe de compilation.
- Passe le cache npm au paramétrage natif de `actions/setup-node@v6` en ajoutant `cache: npm` et `cache-dependency-path: home-lab/package-lock.json`, remplace l’étape d’installation par `npm ci` et ajoute une vérification `npx tauri -V`.
- Le changement a été commité sur la branche courante avec le message de commit `Optimize Rust GitHub Actions build caching`.

### Testing

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/build-tauri.yml'); puts 'YAML OK'"` a réussi et a validé le YAML modifié.
- `cargo metadata --format-version 1 --locked` a réussi et a confirmé la cohérence du workspace Cargo.
- `git diff --check` n’a retourné aucun avertissement ni erreur après les modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba7b50eba483209b5758fd5547c07b)